### PR TITLE
Feature/dm pokes

### DIFF
--- a/catkit2/testbed/proxies/bmc_dm.py
+++ b/catkit2/testbed/proxies/bmc_dm.py
@@ -4,6 +4,7 @@ import numpy as np
 from astropy.io import fits
 from astropy import units
 from astropy.units import Quantity
+from scipy.ndimage import map_coordinates
 
 @ServiceProxy.register_service_interface('bmc_dm')
 class BmcDmProxy(ServiceProxy):


### PR DESCRIPTION
Added dm poke commands to testbed/proxies/bmc_dm.py. I structured these functions as methods for the _BmcDmProxy_ class that always return a command (2x1024 length 1d array). I wasn't sure whether to include the extra flexibility to either return a command or a dm shape (34x34 2d array). Maybe could be included as a feature in a future PR. 