### PR TITLE
Bugfix/broken synchronization signaling

### DIFF
--- a/catkit_core/Synchronization.cpp
+++ b/catkit_core/Synchronization.cpp
@@ -130,6 +130,12 @@ void Synchronization::Wait(long timeout_in_ms, std::function<bool()> condition, 
 			throw std::runtime_error("Waiting time has expired.");
 		}
 
+		if (res == WAIT_FAILED)
+		{
+			m_SharedData->m_NumReadersWaiting--;
+			throw std::runtime_error("An error occured during waiting for the semaphore: " + std::to_string(GetLastError()));
+		}
+
 		if (error_check != nullptr)
 		{
 			try


### PR DESCRIPTION
This fixes a long-standing bug in the synchronization of data streams (after a frame has been written). As the opened semaphore wasn't saved as a member variable, the subsequent wait on that semaphore failed (silently). This leads to inconsistent latency, often as much as multiple milliseconds (up to 20ms observed).

This PR fixes the bug and adds error checking/forwarding.