### PR TITLE
Remove power check during open().

### DIFF
--- a/catkit2/services/snmp_ups/snmp_ups.py
+++ b/catkit2/services/snmp_ups/snmp_ups.py
@@ -44,10 +44,8 @@ class SnmpUps(Service):
             return False
 
     def open(self):
-        # Do one check on power safety during opening.
-        # This is to make sure that we always have at least one power check in the datastream.
-        power_ok = self.get_power_ok()
-        self.power_ok.submit_data(np.array([power_ok], dtype='int8'))
+        # Have at least one frame on the datastream.
+        self.power_ok.submit_data(np.array([False], dtype='int8'))
 
     def main(self):
         while not self.should_shut_down:


### PR DESCRIPTION
Speeds up the startup of the UPS service by removing a time-consuming power check during opening of the service.

The Omega sensor actually is already as fast as it can be, so I did not make any modifications there.

Fixes #34.