### PR TITLE
Do not crash the log forwarder thread on exceptions.

### DIFF
--- a/catkit2/testbed/logging.py
+++ b/catkit2/testbed/logging.py
@@ -90,7 +90,7 @@ class LogDistributor:
                     else:
                         raise RuntimeError('Error during receive') from e
 
-                log_message = log_message[0].decode('ascii')
+                log_message = log_message[0].decode('utf-8')
                 log_message = json.loads(log_message)
 
                 print(f'[{log_message["service_id"]}] {log_message["message"]}')


### PR DESCRIPTION
Adds a try-except around the decoding/forwarding of log messages. Also, decode the messages with UTF-8 rather than just ASCII.

Fixes #53.

- [x] Test on simulator.
- [x] Test on hardware.

FYI @ivalaginja 