### PR TITLE
Fix catching of KeyboardInterrupts by services upon testbed shutdown

### DIFF
--- a/catkit2/testbed/testbed.py
+++ b/catkit2/testbed/testbed.py
@@ -541,7 +541,7 @@ class Testbed:
                 self.log.debug(f'with environment variable {key} = {str(value)}.')
 
         # Start process.
-        if sys.platform == 'Win32':
+        if sys.platform == 'win32':
             startupinfo = subprocess.STARTUPINFO()
             startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
             creationflags = subprocess.CREATE_NEW_CONSOLE


### PR DESCRIPTION
Services on Windows were started using the method of MacOS/Linux. This leads to them not being assigned a new process group, thereby leading to them catching KeyboardInterrupts from the main testbed server process.

Fixes #56.

Tested on my Windows machine. This slipped through the review of #44.