### PR TITLE
Fix NewportXPS relative move.

### DIFF
--- a/catkit2/testbed/proxies/newport_xps.py
+++ b/catkit2/testbed/proxies/newport_xps.py
@@ -39,7 +39,7 @@ class NewportXpsQ8Proxy(ServiceProxy):
     def move_relative(self, motor_id, distance, timeout=None):
         # Get current position.
         stream = getattr(self, motor_id.lower() + '_current_position')
-        current_position = stream.get()
+        current_position = stream.get()[0]
 
         new_position = current_position + distance
 


### PR DESCRIPTION
Changes by #61 made it impossible to do relative moves with the NewportXPS service. This makes it possible again.

Tested by @asahooexo on hardware.