### PR TITLE
Make camera image log messsages debug instead of info.

### DIFF
--- a/catkit2/simulator/simulator.py
+++ b/catkit2/simulator/simulator.py
@@ -258,7 +258,7 @@ class Simulator(Service):
                 # Camera has stopped.
                 return
 
-            self.log.info(f'Reset camera image on {camera_name}.')
+            self.log.debug(f'Reset camera image on {camera_name}.')
 
             integration_time, frame_interval = self.integrating_cameras[camera_name]
 
@@ -294,7 +294,7 @@ class Simulator(Service):
             if camera_name not in self.camera_integrated_power:
                 return
 
-            self.log.info(f'Read out camera image on {camera_name}.')
+            self.log.debug(f'Read out camera image on {camera_name}.')
 
             # Read out camera image and yield image.
             self.camera_readout(camera_name, self.camera_integrated_power[camera_name])


### PR DESCRIPTION
Make camera frame reset and readout log messages debug instead of info. When running the simulator, every time a camera produces a frame, two info log messages are shown. This clutters up the log viewer on the HiCAT GUI a lot, making it harder to find important log messages. This PR changes the log messages to debug, filtering them out more.