### PR TITLE
Recalibation / recofiguration after enclosure, recabling and PC and software upgrade

### DIFF
--- a/catkit2/services/newport_xps_q8/newport_xps_q8.py
+++ b/catkit2/services/newport_xps_q8/newport_xps_q8.py
@@ -15,6 +15,7 @@ except ImportError:
     print("To use the Newport XPS-Q8, you need to set the CATKIT_NEWPORT_LIB_PATH environment variable.")
     raise
 
+
 class NewportXpsQ8(Service):
     _OK_STATES = (7, 11, 12, 42)
 

--- a/catkit2/services/zwo_camera/zwo_camera.py
+++ b/catkit2/services/zwo_camera/zwo_camera.py
@@ -58,7 +58,7 @@ class ZwoCamera(Service):
         num_cameras = zwoasi.get_num_cameras()
         if num_cameras == 0:
             raise RuntimeError("Not a single ZWO camera is connected.")
-        
+
         expected_device_name = self.config['device_name']
         expected_device_id = self.config.get('device_id', None)
 
@@ -96,8 +96,8 @@ class ZwoCamera(Service):
         for c in controls:
             self.camera.set_control_value(controls[c]['ControlType'], controls[c]['DefaultValue'])
 
-        print('Bandwidth defaults',  self.camera.get_controls()['BandWidth'])
-        
+        print('Bandwidth defaults', self.camera.get_controls()['BandWidth'])
+
         print('Bandwidth before:', self.camera.get_control_value(zwoasi.ASI_BANDWIDTHOVERLOAD))
 
         # Set bandwidth overload control to minvalue.


### PR DESCRIPTION
This PR corrects a bug in the error messages for the XPS
This PR also enables the use of the ZWO cameras to be compatible with the new SDK 3.21 from ZWO 

This make it most likely incompatible with HiCATdeux, so some of this would need to be reverted if we need to use HiCATdeux again

- [x] tested on hardware