### PR TITLE
Fixing experiment stalling because lyot theta init

### DIFF
--- a/catkit2/services/newport_xps_q8/newport_xps_q8.py
+++ b/catkit2/services/newport_xps_q8/newport_xps_q8.py
@@ -28,7 +28,7 @@ class NewportXpsQ8(Service):
         self.motor_positions = self.config['motors']
         self.update_interval = self.config['update_interval']
         self.motor_ids = list(self.config['motors'].keys())
-        self.default_atol = self.config['atol']
+        self.default_atol = self.config['atol']['default']
 
         self.motor_commands = {}
         self.motor_current_positions = {}
@@ -44,7 +44,7 @@ class NewportXpsQ8(Service):
     def add_motor(self, motor_id):
         self.motor_commands[motor_id] = self.make_data_stream(motor_id.lower() + '_command', 'float64', [1], 20)
         self.motor_current_positions[motor_id] = self.make_data_stream(motor_id.lower() + '_current_position', 'float64', [1], 20)
-        self.motor_atols[motor_id] = self.config.get([motor_id]['atol'], self.default_atol)
+        self.motor_atols[motor_id] = self.config['atol'].get(motor_id, self.default_atol)
 
     def set_current_position(self, motor_id, position):
         socket_id, lock = self.socket_set[motor_id]

--- a/catkit2/testbed/proxies/newport_xps.py
+++ b/catkit2/testbed/proxies/newport_xps.py
@@ -29,7 +29,7 @@ class NewportXpsQ8Proxy(ServiceProxy):
                     # Timed out. First check if the command is still the same as what we commanded.
                     current_command = command_stream.get()
 
-                    if not np.allclose(current_command, position, atol=self.motor_atols[motor_id]):
+                    if not np.allclose(current_command, position, atol=self._get_motor_atol(motor_id)):
                         # Someone else interrupted our move. Raise an exception.
                         raise RuntimeError(f'Absolute move interrupted or something went wrong when moving {motor_id} to {position} mm.')
 
@@ -60,7 +60,7 @@ class NewportXpsQ8Proxy(ServiceProxy):
         return {key.lower(): value for key, value in self.config['motors'].items()}
 
     def _get_motor_atol(self, motor_id):
-        return self.config.get([motor_id]['atol'], self.config['atol'])
+        return self.config['atol'].get(motor_id, self.config['atol']['default'])
 
     @property
     def motors(self):


### PR DESCRIPTION
## Description

This PR aims to fix the stalling init of the motors described in https://github.com/spacetelescope/hicat-package2/issues/245. Because of different units, the rotation stage requires a different tolerance ("atol") to stop when the target has been reached.    

This PR is related to https://github.com/spacetelescope/hicat-package2/pull/249

 - [x] tested in sim
 - [x] tested on hardware
 