### PR TITLE
Add instructions about how to allow incoming Python connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,39 @@ Shared memory configuration
 On MacOS you need to increase the amount of shared memory that is available to programs. The default (4MB) is by far not enough for anything we do.
 Note: it appears that Catalina seem to allow more shared memory than what is indicated in the documentation, so no action seem to be needed.
 
+Python permissions
+---------------------------
+
+On MacOS, even after having allowed your firewall to receive incoming connections from Python applications while running catkit2,
+it might keep popping up windows asking you to accept incoming connections every single time you start a server or service.
+To prevent this, you can create a self-signed certificate in your keychain. The instructions for that are below,
+found on: https://stackoverflow.com/a/59186900/10112569
+
+```
+With the OS X firewall enabled, you can remove the "Do you want the application "python" to accept incoming network connections?" message.
+
+Create a self-signed certificate.
+
+Open Keychain Access. Applications > Utilities > Keychain Access.
+Keychain Access menu > Certificate Assistant > Create a Certificate...
+Enter a Name like "My Certificate".
+Select Identity Type: Self Signed Root
+Select Certificate Type: Code Signing
+Check the Let me override defaults box
+Click Continue
+Enter a unique Serial Number
+Enter 7300 for Validity Period.
+Click Continue
+Click Continue for the rest of the dialogs
+Now sign your application
+
+  codesign -s "My Certificate" -f $(which python)
+
+In the dialog that appears, click "Allow".
+
+Note that when using a virtual environment, you need to activate the virtual environment before running this command.
+```
+
 Installation
 ------------
 


### PR DESCRIPTION
We have had cases on MacOS machines where starting a server or services makes pop-up windows appear that ask you to accept the incoming connection every single time, even if you had already changed your firewall settings to allow these incoming connections permanently.

This can be solved by creating a self-signed certificate in the keychain. In this PR, I add the instructions on how to do that to the readme.

I tried this and it solved the problem for me.

@ehpor I can change the section title to "Firewall permissions" if that is better suited? Or something else?