### PR TITLE
Update Eigen to v3.4.0.

### DIFF
--- a/catkit_core/CMakeLists.txt
+++ b/catkit_core/CMakeLists.txt
@@ -62,7 +62,7 @@ set(CPPZMQ_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/../extern/cppzmq-4.8.1)
 target_include_directories(catkit_core PUBLIC ${CPPZMQ_INCLUDE_DIR})
 
 # Link Eigen
-set(EIGEN_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/../extern/eigen-3.3.9)
+set(EIGEN_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/../extern/eigen-3.4.0)
 target_include_directories(catkit_core PUBLIC ${EIGEN_INCLUDE_DIR})
 
 # Link nlohmann JSON

--- a/extern/download.sh
+++ b/extern/download.sh
@@ -9,9 +9,9 @@ rm -f v4.8.1.tar.gz
 git clone -b v2.9.2 https://github.com/pybind/pybind11
 
 # Download Eigen
-curl -L https://gitlab.com/libeigen/eigen/-/archive/3.3.9/eigen-3.3.9.tar.gz -O
-tar xfz eigen-3.3.9.tar.gz
-rm -f eigen-3.3.9.tar.gz
+curl -L https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz -O
+tar xfz eigen-3.4.0.tar.gz
+rm -f eigen-3.4.0.tar.gz
 
 # Download nlohmann JSON
 curl -L https://github.com/nlohmann/json/archive/refs/tags/v3.9.1.tar.gz -O


### PR DESCRIPTION
This solves compiler errors on the newest AppleClang compiler.