### PR TITLE
Quadruple the timeout for starting a service.

### DIFF
--- a/catkit_core/ServiceProxy.cpp
+++ b/catkit_core/ServiceProxy.cpp
@@ -10,7 +10,7 @@
 
 using namespace std::string_literals;
 
-const double TIMEOUT_TO_START = 30;  // seconds
+const double TIMEOUT_TO_START = 120;  // seconds
 
 ServiceProxy::ServiceProxy(std::shared_ptr<TestbedProxy> testbed, std::string service_id)
 	: m_Testbed(testbed), m_ServiceId(service_id), m_Client(nullptr), m_State(nullptr),


### PR DESCRIPTION
This hopefully solves intermittent crashes of the Windows CI on hicat-package2. This cannot be tested before merging, so for the reviewer: please look closely at this change.

Fixes https://github.com/spacetelescope/hicat-package2/issues/385