### PR TITLE
add exposure time formula for science cam

### DIFF
--- a/catkit2/services/zwo_camera/zwo_camera.py
+++ b/catkit2/services/zwo_camera/zwo_camera.py
@@ -227,14 +227,10 @@ class ZwoCamera(Service):
 
     @exposure_time.setter
     def exposure_time(self, exposure_time):
-
-        self.exposure_time_step_size = self.config.get('exposure_time_step_size', 1)
-        self.exposure_time_offset_correction = self.config.get('exposure_time_offset_correction', 0)
-        self.exposure_time_base_step = self.config.get('exposure_time_base_step', 1)
-
-        initial_step_offset = self.exposure_time_base_step - self.exposure_time_step_size
-        exposure_time = np.maximum(np.floor((exposure_time - initial_step_offset +  self.exposure_time_offset_correction) / self.exposure_time_step_size), 0)\
-                        * self.exposure_time_step_size + initial_step_offset
+        exposure_time += self.exposure_time_offset_correction
+        exposure_time = np.round((exposure_time - self.exposure_time_base_step) / self.exposure_time_step_size)
+        exposure_time = np.maximum(exposure_time, 0)
+        exposure_time = exposure_time * self.exposure_time_step_size + self.exposure_time_base_step
 
         self.camera.set_control_value(zwoasi.ASI_EXPOSURE, int(exposure_time))
 


### PR DESCRIPTION
Fixes the exposure time issue for science camera. See hicat PR [#318](https://github.com/spacetelescope/hicat-package2/pull/318).

<img width="1769" alt="Screen Shot 2023-08-02 at 1 43 26 PM" src="https://github.com/spacetelescope/catkit2/assets/33359812/507ae6b5-f4e1-4247-8b15-e3da72219409">
