### PR TITLE
Get cmake from conda-forge.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   - libprotobuf
   - conda-forge:hcipy
   - pip
-  - cmake>=3.0.0
+  - conda-forge::cmake>=3.0.0
   - conda-forge::doxygen
   - sphinx
   - conda-forge::sphinx-automodapi


### PR DESCRIPTION
Fixes https://github.com/spacetelescope/hicat-package2/issues/444. For some reason, CMake is broken on Anaconda but it works fine on Conda-forge. I do not know why, but Cmake on Anaconda is not installing the rhash library correctly. Switching to conda-forge helps fix this bug.