### PR TITLE
Bugfix/sci cam sign flip

### DIFF
--- a/catkit2/services/flir_camera/flir_camera.py
+++ b/catkit2/services/flir_camera/flir_camera.py
@@ -133,6 +133,9 @@ class FlirCamera(Service):
         self.height = self.config['height']
         self.offset_x = self.config['offset_x']
         self.offset_y = self.config['offset_y']
+        self.rot90 = self.config.get('rot90', False)
+        self.flip_x = self.config.get('flip_x', False)
+        self.flip_y = self.config.get('flip_y', False)
 
         self.pixel_format = self.config['pixel_format']
         self.adc_bit_depth = self.config['adc_bit_depth']
@@ -144,6 +147,9 @@ class FlirCamera(Service):
         make_property_helper('height')
         make_property_helper('offset_x')
         make_property_helper('offset_y')
+        make_property_helper('rot90')
+        make_property_helper('flip_x')
+        make_property_helper('flip_y')
 
         make_property_helper('sensor_width', read_only=True)
         make_property_helper('sensor_height', read_only=True)
@@ -186,11 +192,18 @@ class FlirCamera(Service):
             pixel_format = PySpin.PixelFormat_Mono16
 
         # Make sure the data stream has the right size and datatype.
-        has_correct_parameters = np.allclose(self.images.shape, [self.height, self.width])
+        if self.rot90:
+            has_correct_parameters = np.allclose(self.images.shape, [self.width, self.height])
+        else:
+            has_correct_parameters = np.allclose(self.images.shape, [self.height, self.width])
+
         has_correct_parameters = has_correct_parameters and (self.images.dtype == pixel_dtype)
 
         if not has_correct_parameters:
-            self.images.update_parameters(pixel_dtype, [self.height, self.width], self.NUM_FRAMES_IN_BUFFER)
+            if self.rot90:
+                self.images.update_parameters(pixel_dtype, [self.width, self.height], self.NUM_FRAMES_IN_BUFFER)
+            else:
+                self.images.update_parameters(pixel_dtype, [self.height, self.width], self.NUM_FRAMES_IN_BUFFER)
 
         self.cam.BeginAcquisition()
         self.is_acquiring.submit_data(np.array([1], dtype='int8'))
@@ -214,7 +227,7 @@ class FlirCamera(Service):
                         continue
 
                     img = image_result.Convert(pixel_format).GetNDArray().astype(pixel_dtype, copy=False)
-
+                    img = self.rot_flip_image(img)
                     # Submit image to datastream.
                     self.images.submit_data(img)
 
@@ -262,6 +275,17 @@ class FlirCamera(Service):
     def get_temperature(self):
         with self.mutex:
             return self.cam.DeviceTemperature.GetValue()
+
+    def rot_flip_image(self, img):
+        # rotation needs to happen first
+        if self.rot90:
+            img = np.rot90(img)
+        if self.flip_x:
+            img = np.flipud(img)
+        if self.flip_y:
+            img = np.fliplr(img)
+        return img
+
 
 if __name__ == '__main__':
     service = FlirCamera()

--- a/catkit2/services/flir_camera/flir_camera.py
+++ b/catkit2/services/flir_camera/flir_camera.py
@@ -147,9 +147,9 @@ class FlirCamera(Service):
         make_property_helper('height')
         make_property_helper('offset_x')
         make_property_helper('offset_y')
-        make_property_helper('rot90')
-        make_property_helper('flip_x')
-        make_property_helper('flip_y')
+        make_property_helper('rot90', read_only=True)
+        make_property_helper('flip_x', read_only=True)
+        make_property_helper('flip_y', read_only=True)
 
         make_property_helper('sensor_width', read_only=True)
         make_property_helper('sensor_height', read_only=True)

--- a/catkit2/services/zwo_camera/zwo_camera.py
+++ b/catkit2/services/zwo_camera/zwo_camera.py
@@ -376,8 +376,8 @@ class ZwoCamera(Service):
         # Define the translation matrix T to get to the center of the ROI.
         T = np.zeros((3, 3))
         np.fill_diagonal(T, 1)
-        T[0][-1] = self.width / 2
-        T[1][-1] = -self.height / 2  # Negative due to origin in upper left.
+        T[0][-1] = -self.width / 2
+        T[1][-1] = -self.height / 2
 
         # Initialize rotation matrix R.
         R = np.zeros((3, 3))
@@ -401,11 +401,11 @@ class ZwoCamera(Service):
 
         if self.flip_x:
             # Define x reflection matrix.
-            X[1][1] = -1
+            X[0][0] = -1
 
         if self.flip_y:
             # Define y reflection matrix.
-            Y[0][0] = -1
+            Y[1][1] = -1
 
         # Define translation matrix back so that the origin is in the upper left as expected.
         T_back = np.zeros((3, 3))

--- a/catkit2/services/zwo_camera/zwo_camera.py
+++ b/catkit2/services/zwo_camera/zwo_camera.py
@@ -176,9 +176,9 @@ class ZwoCamera(Service):
         make_property_helper('height', requires_stopped_acquisition=True)
         make_property_helper('offset_x')
         make_property_helper('offset_y')
-        make_property_helper('rot90')
-        make_property_helper('flip_x')
-        make_property_helper('flip_y')
+        make_property_helper('rot90', read_only=True)
+        make_property_helper('flip_x', read_only=True)
+        make_property_helper('flip_y', read_only=True)
 
         make_property_helper('sensor_width', read_only=True)
         make_property_helper('sensor_height', read_only=True)

--- a/catkit2/services/zwo_camera/zwo_camera.py
+++ b/catkit2/services/zwo_camera/zwo_camera.py
@@ -128,11 +128,12 @@ class ZwoCamera(Service):
 
         offset_x, offset_y = self.get_camera_offset(offset_x, offset_y)
 
-        self.offset_x = offset_x
-        self.offset_y = offset_y
-        self.rot90 = rot90
-        self.flip_x = flip_x
-        self.flip_y = flip_y
+        if self.rot90:
+            # If rotating by 90 degrees swap the values for width and height.
+            w = self.width
+            h = self.height
+            self.width = h
+            self.height = w
 
         self.gain = self.config.get('gain', 0)
         self.exposure_time_step_size = self.config.get('exposure_time_step_size', 1)

--- a/catkit2/services/zwo_camera/zwo_camera.py
+++ b/catkit2/services/zwo_camera/zwo_camera.py
@@ -117,8 +117,6 @@ class ZwoCamera(Service):
         self.camera.set_image_type(zwoasi.ASI_IMG_RAW16)
 
         # Set device values from config file (set width and height before offsets)
-        # TODO offset x and y defined with respect to CAMERA coords (width, height). If we want it
-        #  to be with respect to the cameras given axis (if rotated) should write a transform helper function
         offset_x = self.config.get('offset_x', 0)
         offset_y = self.config.get('offset_y', 0)
         rot90 = self.config.get('rot90', False)
@@ -127,6 +125,9 @@ class ZwoCamera(Service):
 
         self.width = self.config.get('width', self.sensor_width - offset_x)
         self.height = self.config.get('height', self.sensor_height - offset_y)
+
+        offset_x, offset_y = self.get_camera_offset(offset_x, offset_y)
+
         self.offset_x = offset_x
         self.offset_y = offset_y
         self.rot90 = rot90

--- a/catkit2/services/zwo_camera/zwo_camera.py
+++ b/catkit2/services/zwo_camera/zwo_camera.py
@@ -410,8 +410,14 @@ class ZwoCamera(Service):
         # Define translation matrix back so that the origin is in the upper left as expected.
         T_back = np.zeros((3, 3))
         np.fill_diagonal(T_back, 1)
-        T_back[0][-1] = -self.width / 2
-        T_back[1][-1] = self.height / 2
+
+        if self.rot90:
+            # Want to come back to new origin for which the height/width dimensions will be flipped if rotated.
+            T_back[0][-1] = self.height / 2
+            T_back[1][-1] = self.width / 2
+        else:
+            T_back[0][-1] = self.width / 2
+            T_back[1][-1] = self.height / 2
 
         # Perform the dot product. First flip in x to establish top left origin, then translate to ROI center, rotate,
         # translate back to origin, flip in x, and finally flip in y.

--- a/catkit2/services/zwo_camera/zwo_camera.py
+++ b/catkit2/services/zwo_camera/zwo_camera.py
@@ -348,7 +348,7 @@ class ZwoCamera(Service):
             img = np.flipud(img)
         if self.flip_y:
             img = np.fliplr(img)
-        return img
+        return np.ascontiguousarray(img)
 
 
 if __name__ == '__main__':

--- a/catkit2/services/zwo_camera/zwo_camera.py
+++ b/catkit2/services/zwo_camera/zwo_camera.py
@@ -383,12 +383,10 @@ class ZwoCamera(Service):
         R = np.zeros((3, 3))
 
         # Initialize x reflection matrix, X. Defaults to unity matrix.
-        X = np.zeros((3, 3))
-        np.fill_diagonal(X, 1)
+        X = np.eye(3, 3)
 
         # Initialize y reflection matrix, Y. Defaults to unity matrix.
-        Y = np.zeros((3, 3))
-        np.fill_diagonal(Y, 1)
+        Y = np.eye(3, 3)
 
         if self.rot90:
             # Define rotation matrix.
@@ -408,8 +406,7 @@ class ZwoCamera(Service):
             Y[1][1] = -1
 
         # Define translation matrix back so that the origin is in the upper left as expected.
-        T_back = np.zeros((3, 3))
-        np.fill_diagonal(T_back, 1)
+        T_back = np.eye(3, 3)
 
         if self.rot90:
             # Want to come back to new origin for which the height/width dimensions will be flipped if rotated.

--- a/catkit2/services/zwo_camera/zwo_camera.py
+++ b/catkit2/services/zwo_camera/zwo_camera.py
@@ -116,7 +116,7 @@ class ZwoCamera(Service):
         # Set image format to be RAW16, although camera is only 12-bit.
         self.camera.set_image_type(zwoasi.ASI_IMG_RAW16)
 
-        # Set device values from config file (set width and height before offsets)
+        # Set device values from config file.
         offset_x = self.config.get('offset_x', 0)
         offset_y = self.config.get('offset_y', 0)
         self.rot90 = self.config.get('rot90', False)
@@ -128,6 +128,7 @@ class ZwoCamera(Service):
 
         self.offset_x, self.offset_y = self.get_camera_offset(offset_x, offset_y)
 
+        # Note that get_camera_offset must be called before updating the values of self.width and self.height.
         if self.rot90:
             # If rotating by 90 degrees swap the values for width and height.
             w = self.width

--- a/catkit2/services/zwo_camera/zwo_camera.py
+++ b/catkit2/services/zwo_camera/zwo_camera.py
@@ -421,7 +421,7 @@ class ZwoCamera(Service):
         # Perform the dot product. First flip in x to establish top left origin, then translate to ROI center, rotate,
         # translate back to origin, flip in x, and finally flip in y.
         coords = [x, y, 1]
-        new_coords = np.linalg.multi_dot([Y, X, T_back, R, T, coords])
+        new_coords = np.linalg.multi_dot([T_back, Y, X, R, T, coords])
 
         return new_coords[0], new_coords[1]
 

--- a/catkit2/services/zwo_camera/zwo_camera.py
+++ b/catkit2/services/zwo_camera/zwo_camera.py
@@ -119,14 +119,14 @@ class ZwoCamera(Service):
         # Set device values from config file (set width and height before offsets)
         offset_x = self.config.get('offset_x', 0)
         offset_y = self.config.get('offset_y', 0)
-        rot90 = self.config.get('rot90', False)
-        flip_x = self.config.get('flip_x', False)
-        flip_y = self.config.get('flip_y', False)
+        self.rot90 = self.config.get('rot90', False)
+        self.flip_x = self.config.get('flip_x', False)
+        self.flip_y = self.config.get('flip_y', False)
 
         self.width = self.config.get('width', self.sensor_width - offset_x)
         self.height = self.config.get('height', self.sensor_height - offset_y)
 
-        offset_x, offset_y = self.get_camera_offset(offset_x, offset_y)
+        self.offset_x, self.offset_y = self.get_camera_offset(offset_x, offset_y)
 
         if self.rot90:
             # If rotating by 90 degrees swap the values for width and height.


### PR DESCRIPTION
See affiliated PR on hicat-package2 (https://github.com/spacetelescope/hicat-package2/pull/480)

Add infrastructure in camera services to rotate and/or flip the images on the camera.

The camera rotation happens first and defines which camera axis (width or height) is aligned with the gravity vector of the testbed. Defining `rot90` to be `True` will perform one counter-clockwise 90 degree rotation. If a clockwise rotation is desired then `flip_y` should also be set to `True`.

The flips (`flip_x`, and `flip_y`), with the exception of the example above, are meant to be defined with respect to the optical axis (e.g. whether a lens upstream of the camera has flipped the image). 

Notably `offset_x` and `offset_y` values are not changed with the reflections and rotations since these are fundamentally defined with respect to the camera array and the setters and getters for these values are directly given to the setROI functions in the vendor camera control software itself. I believe this is alright since finding these values should not have to occur very frequently and the user can take care to make sure they are defined with respect to the coordinate system of the camera itself.

## Tasks before review

<!-- You can remove this section if this is a finished PR already. -->

- Test on hardware (might have to do with phase retrieval camera since this is the only current one with a rotation)
- Optimize for speed and memory usage 