### PR TITLE
Fix sleep when no change in spectrum is requested

### DIFF
--- a/catkit2/testbed/proxies/nkt_superk.py
+++ b/catkit2/testbed/proxies/nkt_superk.py
@@ -47,7 +47,7 @@ class NktSuperkProxy(ServiceProxy):
         swp = center_wavelength + bandwidth / 2
 
         current_lwp = self.lwp_setpoint.get()[0]
-        current_swp = self.lwp_setpoint.get()[0]
+        current_swp = self.swp_setpoint.get()[0]
 
         # Back out early if we do not need to move the VARIA filter.
         if np.allclose(lwp, current_lwp) and np.allclose(swp, current_swp):


### PR DESCRIPTION
Lets the VARIA return early when there is no change in filters. Fixes https://github.com/spacetelescope/catkit2/issues/125

Also raises an error when negative bandwidths are requested. Fixes https://github.com/spacetelescope/hicat-package2/issues/291

This PR supersedes PR https://github.com/spacetelescope/catkit2/pull/104.