### PR TITLE
Hardcode flip for science camera as a hack

### DIFF
--- a/catkit2/services/zwo_camera/zwo_camera.py
+++ b/catkit2/services/zwo_camera/zwo_camera.py
@@ -201,7 +201,11 @@ class ZwoCamera(Service):
             while self.should_be_acquiring.is_set() and not self.should_shut_down:
                 img = self.camera.capture_video_frame(timeout=timeout)
 
-                self.images.submit_data(img.astype('float32'))
+                # 2023-10-26 Temporary fix for HiCAT
+                if self.id == 'science_camera':
+                    self.images.submit_data(np.ascontiguousarray(np.flip(img.astype('float32'))))
+                else:
+                    self.images.submit_data(img.astype('float32'))
         finally:
             # Stop acquisition.
             self.camera.stop_video_capture()


### PR DESCRIPTION
A very temporary hack until #124 is fixed properly. This is necessary due to hardware changes on HiCAT. It will be removed right after #124 is fixed.

Edit: reverted in https://github.com/spacetelescope/catkit2/pull/451