### PR TITLE
Delta PR: Use frame handler for AlliedVision camera

### DIFF
--- a/catkit2/services/AlliedVision_camera/AlliedVision_camera.py
+++ b/catkit2/services/AlliedVision_camera/AlliedVision_camera.py
@@ -85,7 +85,7 @@ class AlliedVisionCamera(Service):
     def close(self):
         self.cam = None
 
-    def acquisition_loop(self, cam, frame):
+    def acquisition_loop(self):
         # Make sure the data stream has the right size and datatype.
         has_correct_parameters = np.allclose(self.images.shape, [self.height, self.width])
 


### PR DESCRIPTION
Restoring the main loop and adapting the acquisition loop to use a frame handler.

It is unclear at this point whether this will work as expected since the camera runs a loop itself when streaming, to be tested.