### PR TITLE
Improve CLD service and add simulated CLD service

### DIFF
--- a/catkit2/services/thorlabs_cld101x/thorlabs_cld101x.py
+++ b/catkit2/services/thorlabs_cld101x/thorlabs_cld101x.py
@@ -35,8 +35,6 @@ class ThorlabsCLD101X(Service):
         # Read max current setpoint.
         self.max_current = float(self.connection.query('source1:current:limit:amplitude?'))  # in Ampere
 
-        self.make_command('set_current_setpoint', self.set_current_setpoint)
-
     def main(self):
         while not self.should_shut_down:
             try:

--- a/catkit2/services/thorlabs_cld101x_sim/thorlabs_cld101x_sim.py
+++ b/catkit2/services/thorlabs_cld101x_sim/thorlabs_cld101x_sim.py
@@ -13,7 +13,6 @@ class ThorlabsCLD101XSim(Service):
         self.current_percent = self.make_data_stream(f'current_percent_{self.wavelength}', 'float32', [1], 20)
 
     def open(self):
-        self.make_command('set_current_setpoint', self.set_current_setpoint)
         self.max_current = 0.25  # in Ampere  # TODO: Get this from config?
 
     def main(self):


### PR DESCRIPTION
Fixes #145.

### What this PR does:
- add a data stream for the percentage of the maximum current for a laser diode to be set to
- have the main() of the laser monitor that data stream and set the diode current when new frame is received on data stream
- add wavelength of laser diode to data stream names to avoid confusion with other streams of other laser diodes that are used at the same time
- add a simulated service for the CLD

These changes are necessary for the refactor in https://github.com/ivalaginja/thd-controls/pull/119.

### Todo before merging:

- [x] test in simulation
- [x] test on hardware