### PR TITLE
Bugfix: Thorlabs CLD hardware service

### DIFF
--- a/catkit2/services/thorlabs_cld101x/thorlabs_cld101x.py
+++ b/catkit2/services/thorlabs_cld101x/thorlabs_cld101x.py
@@ -41,7 +41,7 @@ class ThorlabsCLD101X(Service):
                 # Get an update for this channel
                 frame = self.current_percent.get_next_frame(10)
                 # Set to new current
-                self.set_current_setpoint(frame.data)
+                self.set_current_setpoint(frame.data[0])
 
             except Exception:
                 # Timed out. This is used to periodically check the shutdown flag.

--- a/catkit2/services/thorlabs_cld101x_sim/thorlabs_cld101x_sim.py
+++ b/catkit2/services/thorlabs_cld101x_sim/thorlabs_cld101x_sim.py
@@ -21,7 +21,7 @@ class ThorlabsCLD101XSim(Service):
                 # Get an update for this channel
                 frame = self.current_percent.get_next_frame(10)
                 # Set to new current
-                self.set_current_setpoint(frame.data)
+                self.set_current_setpoint(frame.data[0])
 
             except Exception:
                 # Timed out. This is used to periodically check the shutdown flag.


### PR DESCRIPTION
I was testing the `ThorlabsCLD101X` service on hardware on THD2 today and ran into a couple of bugs that I fix in this PR:
- extract the float from the received DataFrame array, needed for the hardware command
- do the above in the simulated service as well
- specify the dtype of the array being submitted to a DataStream after commanding the laser, like already done in the simulated service
- remove check of current laser setting before sending new command

Tested on hardware and works.

Tested in sim and still works.