### PR TITLE
Correct order of arguments to np.clip() in ni_daq service

### DIFF
--- a/catkit2/services/ni_daq/ni_daq.py
+++ b/catkit2/services/ni_daq/ni_daq.py
@@ -140,7 +140,7 @@ class NiDaq(Service):
             self.log.warning(f'Min voltage: {np.min(values)} V; max voltage: {np.max(values)} V.')
             self.log.warning(f'Voltage limits: {self.volt_limit_min} V < voltage < {self.volt_limit_max} V.')
 
-        values = np.clip(self.volt_limit_min, self.volt_limit_max, values)
+        values = np.clip(values, self.volt_limit_min, self.volt_limit_max)
 
         self.task.write(values)
 


### PR DESCRIPTION
Fix typo in `np.clip()` that makes sure to cut the input voltage values to the allowable range as defined in the `services.yml`.

Test results reported in #91.