### PR TITLE
Add simulated service for AimTTiPL-P device

### DIFF
--- a/catkit2/services/aimtti_plp_device_sim/aimtti_plp_device_sim.py
+++ b/catkit2/services/aimtti_plp_device_sim/aimtti_plp_device_sim.py
@@ -110,11 +110,11 @@ class AimttiPLPDeviceSim(Service):
 
     def set_voltage(self, channel_name, value):
         """Set output voltage for a channel."""
-        pass
+        self.log.warning("Setting voltage on simulated AimTTiPL-P not implemented.")
 
     def set_current(self, channel_name, value):
         """Set output current limit for a channel."""
-        pass
+        self.log.warning("Setting current on simulated AimTTiPL-P not implemented.")
 
     def query_commanded_voltage(self, channel_name):
         """Return set voltage of output for a channel (not the measured voltage)."""


### PR DESCRIPTION
Depends on #149.

Adds a simulated service that is supposed to manage the same data streams like the hardware service. It currently does not interact with the simulator at all.

@ehpor I wasn't sure whether this was ok since it only contains the data stream handling, so I separated this into a different PR from the hardware service.