### PR TITLE
Add services for Ocean Optics spectrometers 

### DIFF
--- a/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
+++ b/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
@@ -158,10 +158,10 @@ class OceanOpticsSpectrometer(Service):
 
         This property can be used to set the exposure time of the spectrometer.
 
-        If exposure_time parameter is inferior to the minimum allowed exposure time for this
-        spectrometer (set by ocean optics), it is set to the minimum allowed exposure time.
-        If exposure_time is larger to the maximum allowed exposure time, it is set to the
-        minimum allowed exposure time.
+        If the `exposure_time` parameter is inferior to the minimum allowed exposure time for this
+        spectrometer (set by Ocean Optics), it is set to the minimum allowed exposure time.
+        If the `exposure_time` is larger than the maximum allowed exposure time, it is set to the
+        maximum allowed exposure time.
 
         Parameters
         ----------

--- a/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
+++ b/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
@@ -1,0 +1,155 @@
+'''
+This module contains a service for Ocean Optics Sectrometer
+
+This service is a wrapper around the python seabreeze package
+It provides a simple interface to control the spectro and acquire spectras.
+'''
+
+import seabreeze
+
+seabreeze.use('pyseabreeze')
+
+from seabreeze.spectrometers import Spectrometer as spct
+from catkit2.testbed.service import Service
+
+
+class OceanOpticsSpectro(Service):
+    '''
+    Service for Ocean Optics Spectrometer.
+
+    This service is a wrapper around the python seabreeze package
+    It provides a simple interface to control the spectro and acquire spectras.
+
+    Attributes
+    ----------
+    spectrometer : Spectrometer
+        The spectrometer to control.
+    model : str
+        The model of the spectrometer.
+    pixels_number : int
+        number of pix in the spectras
+    wavelengths : NDArray[numpy.float_]
+        A NDArray with the wl of the spectrometer.
+    spectras : DataStream
+        A data stream to submit the spectras from the spectrometer.
+    NUM_FRAMES : int
+        The number of frames to allocate for the data streams.
+
+    Methods
+    -------
+    open()
+        Open the service.
+    main()
+        The main function of the service.
+    close()
+        Close the service.
+    get_spectra()
+        Get a spectra from the spectrometer.
+    exposure_time()
+        Set the exposure time of the spectrometer.
+
+    '''
+    NUM_FRAMES = 20
+
+    def __init__(self):
+        '''
+        Create a new OceanOpticsSpectro service.
+
+        '''
+        super().__init__('OceanOpticsSpectro')
+
+        self.spectrometer = None
+        self.model = None
+        self.pixels_number = None
+
+        self.wavelengths = None
+        self.spectras = None
+
+    def open(self):
+        '''
+        Open the service.
+
+        This function is called when the service is opened.
+        It initializes the spectrometer and creates the data streams and properties.
+
+        Raises
+        ------
+        RuntimeError
+            If the spectro cannot be found.
+
+        '''
+
+        # Find the spectrometer
+        self.serial_number = str(self.config['serial_number'])
+
+        try:
+            self.spectrometer = spct.from_serial_number(self.serial_number)
+        except:
+            raise RuntimeError(f'Could not find spectrometer with serial number {self.serial_number}')
+
+        # Set the exposure time
+        self.exposure_time = self.config.get('exposure_time', 1000)
+        self.make_property('exposure_time', lambda: getattr(self, 'exposure_time'),
+                           lambda val: setattr(self, 'exposure_time', val))
+
+        # exctract attributes
+        self.model = self.spectrometer.model
+        self.pixels_number = self.spectrometer.pixels
+        self.wavelengths = self.spectrometer.wavelengths()
+
+        # Create datastreams
+        # Use the full sensor size here to always allocate enough shared memory.
+        self.spectras = self.make_data_stream('spectras', 'float32', self.pixels_number, self.NUM_FRAMES)
+
+    def main(self):
+        '''
+        The main function of the service.
+
+        This function is called when the service is started.
+        '''
+        while not self.should_shut_down:
+            spectra = self.get_spectra()
+            self.spectras.submit_data(spectra, dtype='float32')
+
+    def get_spectra(self):
+        return self.spectrometer.intensities()
+
+    @exposure_time.setter
+    def exposure_time(self, exposure_time: int):
+        '''
+        Set the exposure time in microseconds.
+
+        This property can be used to set the exposure time of the spectr0.
+
+        Parameters
+        ----------
+        exposure_time : int
+            The exposure time in microseconds.
+        
+        Raises
+        ------
+        ValueError
+            If the exposure time is not in the range of the accepted spectrometer values.
+        '''
+
+        int_time_range = self.spectrometer.integration_time_micros_limits
+        if exposure_time < int_time_range[0] or exposure_time > int_time_range[1]:
+            raise ValueError(
+                f"Ocean Optics: integration time need to be in [{int_time_range[0]}, {int_time_range[1]}] range (ms)")
+
+        self.spectrometer.integration_time_micros(exposure_time)
+
+    def close(self):
+        '''
+        Close the service.
+
+        This function is called when the service is closed.
+        It close the spectro loop and cleans up the data streams.
+        '''
+        self.spectrometer.close()
+        self.spectrometer = None
+
+
+if __name__ == '__main__':
+    service = OceanOpticsSpectro()
+    service.run()

--- a/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
+++ b/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
@@ -116,7 +116,7 @@ class OceanOpticsSpectrometer(Service):
         while not self.should_shut_down:
             if self.should_be_acquiring.wait(0.05):
                 self.get_spectra()
-    
+
     def start_acquisition(self):
         '''
         Start the acquisition loop.
@@ -132,7 +132,6 @@ class OceanOpticsSpectrometer(Service):
         This function ends the acquisition loop.
         '''
         self.should_be_acquiring.clear()
-
 
     def get_spectra(self):
         spectra = self.spectrometer.intensities()

--- a/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
+++ b/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
@@ -2,7 +2,6 @@
 This module contains a service for Ocean Optics Spectrometers.
 '''
 import numpy as np
-import threading
 
 from seabreeze.spectrometers import Spectrometer
 from seabreeze.spectrometers import SeaBreezeError

--- a/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
+++ b/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
@@ -52,17 +52,19 @@ class OceanOpticsSpectrometer(Service):
         '''
         super().__init__('oceanoptics_spectrometer')
 
+        # self.serial_number = str(self.config['serial_number'])
+        # self.interval = self.config.get('interval', 1)
+        # self._exposure_time = self.config.get('exposure_time', 1000)
         self.serial_number = None
+        self.interval = None
+        self._exposure_time = None
+
         self.spectrometer = None
         self.model = None
         self.pixels_number = None
 
         self.spectra = None
         self.is_saturating = None
-
-        self.interval = self.config.get('interval', 1)
-
-        self._exposure_time = None
 
     def open(self):
         '''
@@ -77,8 +79,12 @@ class OceanOpticsSpectrometer(Service):
             If the spectrometer cannot be found.
         '''
 
-        # Find the spectrometer
         self.serial_number = str(self.config['serial_number'])
+        self.interval = self.config.get('interval', 1)
+        self._exposure_time = self.config.get('exposure_time', 1000)
+
+        # Find the spectrometer
+        
         try:
             self.spectrometer = Spectrometer.from_serial_number(self.serial_number)
         except SeaBreezeError:
@@ -89,7 +95,6 @@ class OceanOpticsSpectrometer(Service):
         self.pixels_number = self.spectrometer.pixels
 
         # Define and set defaut exposure time
-        self._exposure_time = self.config.get('exposure_time', 1000)
         self.exposure_time = self._exposure_time
 
         # Create datastreams

--- a/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
+++ b/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
@@ -8,7 +8,7 @@ It provides a simple interface to control the spectro and acquire spectras.
 import threading
 
 from seabreeze.spectrometers import Spectrometer as spct
-from seabreeze.spectrometers import SeabreezeError
+from seabreeze.spectrometers import SeaBreezeError
 
 from catkit2.testbed.service import Service
 
@@ -91,7 +91,7 @@ class OceanOpticsSpectrometer(Service):
 
         try:
             self.spectrometer = spct.from_serial_number(self.serial_number)
-        except SeabreezeError:
+        except SeaBreezeError:
             raise ImportError(f'OceanOptics: Could not find spectrometer with serial number {self.serial_number}')
 
         # exctract attributes
@@ -120,22 +120,20 @@ class OceanOpticsSpectrometer(Service):
     def start_acquisition(self):
         '''
         Start the acquisition loop.
-
-        This function starts the acquisition loop.
         '''
         self.should_be_acquiring.set()
 
     def end_acquisition(self):
         '''
         End the acquisition loop.
-
-        This function ends the acquisition loop.
         '''
         self.should_be_acquiring.clear()
 
     def get_spectra(self):
-        spectra = self.spectrometer.intensities()
-        self.spectras.submit_data(spectra, dtype='float32')
+        '''
+        Get spectrum from spectrometer and submit it to the data stream.
+        '''
+        self.spectras.submit_data(self.spectrometer.intensities(), dtype='float32')
 
     @property
     def exposure_time(self):

--- a/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
+++ b/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
@@ -25,7 +25,7 @@ class OceanOpticsSpectrometer(Service):
     model : str
         The model of the spectrometer.
     pixels_number : int
-        number of pix in the spectrum.
+        number of pixels in the spectrum.
     spectra : DataStream
         A data stream to submit spectra from the spectrometer.
     is_saturating : DataStream
@@ -60,9 +60,6 @@ class OceanOpticsSpectrometer(Service):
         self.model = None
         self.pixels_number = None
 
-        self.spectra = None
-        self.is_saturating = None
-
     def open(self):
         '''
         Open the service.
@@ -72,7 +69,7 @@ class OceanOpticsSpectrometer(Service):
 
         Raises
         ------
-        RuntimeError
+        ImportError
             If the spectrometer cannot be found.
         '''
 
@@ -86,7 +83,7 @@ class OceanOpticsSpectrometer(Service):
         self.model = self.spectrometer.model
         self.pixels_number = self.spectrometer.pixels
 
-        # Define and set defaut exposure time
+        # Define and set default exposure time.
         self.exposure_time = self._exposure_time
 
         # Create datastreams
@@ -158,7 +155,6 @@ class OceanOpticsSpectrometer(Service):
         '''
         Set the exposure time in microseconds.
 
-        This property can be used to set the exposure time of the spectrometer.
         if exposure_time < min allowed exp time: exposure_time =  min allowed exp time
         if exposure_time > max allowed exp time: exposure_time =  max allowed exp time
 
@@ -167,10 +163,6 @@ class OceanOpticsSpectrometer(Service):
         exposure_time : int
             The exposure time in microseconds.
 
-        Raises
-        ------
-        ValueError
-            If the exposure time is not in the range of the accepted spectrometer values.
         '''
         int_time_range = self.spectrometer.integration_time_micros_limits
         if exposure_time < int_time_range[0]:
@@ -186,7 +178,7 @@ class OceanOpticsSpectrometer(Service):
         Close the service.
 
         This function is called when the service is closed.
-        It close the spectrometer and cleans up the data streams.
+        It closes the spectrometer.
         '''
         self.spectrometer.close()
         self.spectrometer = None

--- a/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
+++ b/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
@@ -115,13 +115,13 @@ class OceanOpticsSpectrometer(Service):
         '''
         while not self.should_shut_down:
             self.should_be_acquiring.set()
-            self.get_spectra()
+            if self.should_be_acquiring.wait(0.05):
+                self.get_spectra()
+                self.should_be_acquiring.clear()
 
     def get_spectra(self):
-        if self.should_be_acquiring.wait(0.05):
-            spectra = self.spectrometer.intensities()
-            self.spectras.submit_data(spectra, dtype='float32')
-            self.should_be_acquiring.clear()
+        spectra = self.spectrometer.intensities()
+        self.spectras.submit_data(spectra, dtype='float32')
 
     @property
     def exposure_time(self):

--- a/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
+++ b/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
@@ -114,10 +114,25 @@ class OceanOpticsSpectrometer(Service):
         This function is called when the service is started.
         '''
         while not self.should_shut_down:
-            self.should_be_acquiring.set()
             if self.should_be_acquiring.wait(0.05):
                 self.get_spectra()
-                self.should_be_acquiring.clear()
+    
+    def start_acquisition(self):
+        '''
+        Start the acquisition loop.
+
+        This function starts the acquisition loop.
+        '''
+        self.should_be_acquiring.set()
+
+    def end_acquisition(self):
+        '''
+        End the acquisition loop.
+
+        This function ends the acquisition loop.
+        '''
+        self.should_be_acquiring.clear()
+
 
     def get_spectra(self):
         spectra = self.spectrometer.intensities()

--- a/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
+++ b/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
@@ -10,7 +10,7 @@ from catkit2.testbed.service import Service
 from seabreeze.spectrometers import Spectrometer as spct
 from seabreeze.spectrometers import SeabreezeError
 
-class OceanOpticsSpectro(Service):
+class OceanOpticsSpectrometer(Service):
     '''
     Service for Ocean Optics Spectrometer.
 
@@ -50,10 +50,10 @@ class OceanOpticsSpectro(Service):
 
     def __init__(self):
         '''
-        Create a new OceanOpticsSpectro service.
+        Create a new OceanOpticsSpectrometer service.
 
         '''
-        super().__init__('OceanOpticsSpectro')
+        super().__init__('oceanoptics_spectrometer')
 
         self.spectrometer = None
         self.model = None
@@ -105,12 +105,12 @@ class OceanOpticsSpectro(Service):
         This function is called when the service is started.
         '''
         while not self.should_shut_down:
-            spectra = self.get_spectra()
-            self.spectras.submit_data(spectra, dtype='float32')
+            self.get_spectra()
 
     def get_spectra(self):
-        return self.spectrometer.intensities()
-
+        spectra = self.spectrometer.intensities() 
+        self.spectras.submit_data(spectra, dtype='float32')
+ 
     @exposure_time.setter
     def exposure_time(self, exposure_time: int):
         '''
@@ -148,5 +148,5 @@ class OceanOpticsSpectro(Service):
 
 
 if __name__ == '__main__':
-    service = OceanOpticsSpectro()
+    service = OceanOpticsSpectrometer()
     service.run()

--- a/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
+++ b/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
@@ -5,13 +5,10 @@ This service is a wrapper around the python seabreeze package
 It provides a simple interface to control the spectro and acquire spectras.
 '''
 
-import seabreeze
-
-seabreeze.use('pyseabreeze')
-
-from seabreeze.spectrometers import Spectrometer as spct
 from catkit2.testbed.service import Service
 
+from seabreeze.spectrometers import Spectrometer as spct
+from seabreeze.spectrometers import SeabreezeError
 
 class OceanOpticsSpectro(Service):
     '''
@@ -44,7 +41,7 @@ class OceanOpticsSpectro(Service):
     close()
         Close the service.
     get_spectra()
-        Get a spectra from the spectrometer.
+        Get a spectrum from the spectrometer.
     exposure_time()
         Set the exposure time of the spectrometer.
 
@@ -84,8 +81,8 @@ class OceanOpticsSpectro(Service):
 
         try:
             self.spectrometer = spct.from_serial_number(self.serial_number)
-        except:
-            raise RuntimeError(f'Could not find spectrometer with serial number {self.serial_number}')
+        except SeabreezeError:
+            raise ImportError(f'OceanOptics: Could not find spectrometer with serial number {self.serial_number}')
 
         # Set the exposure time
         self.exposure_time = self.config.get('exposure_time', 1000)
@@ -125,7 +122,7 @@ class OceanOpticsSpectro(Service):
         ----------
         exposure_time : int
             The exposure time in microseconds.
-        
+
         Raises
         ------
         ValueError
@@ -135,7 +132,7 @@ class OceanOpticsSpectro(Service):
         int_time_range = self.spectrometer.integration_time_micros_limits
         if exposure_time < int_time_range[0] or exposure_time > int_time_range[1]:
             raise ValueError(
-                f"Ocean Optics: integration time need to be in [{int_time_range[0]}, {int_time_range[1]}] range (ms)")
+                f"OceanOptics: integration time need to be in [{int_time_range[0]}, {int_time_range[1]}] range (ms)")
 
         self.spectrometer.integration_time_micros(exposure_time)
 

--- a/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
+++ b/catkit2/services/oceanoptics_spectrometer/oceanoptics_spectrometer.py
@@ -28,7 +28,7 @@ class OceanOpticsSpectrometer(Service):
     pixels_number : int
         number of pix in the spectrum.
     wavelengths : NDArray[numpy.float_]
-        A NDArray with the wl of the spectrometer.
+        A NDArray with the wavelengths of the spectrometer.
     spectra : DataStream
         A data stream to submit spectra from the spectrometer.
     should_be_acquiring : threading.Event
@@ -50,14 +50,12 @@ class OceanOpticsSpectrometer(Service):
         Get a spectrum from the spectrometer.
     exposure_time()
         Set the exposure time of the spectrometer.
-
     '''
     NUM_FRAMES = 20
 
     def __init__(self):
         '''
         Create a new OceanOpticsSpectrometer service.
-
         '''
         super().__init__('oceanoptics_spectrometer')
 
@@ -132,7 +130,7 @@ class OceanOpticsSpectrometer(Service):
 
     def take_one_spectrum(self):
         '''
-        measure one spectrum and submit it to the data stream.
+        Measure one spectrum and submit it to the data stream.
         '''
         self.spectra.submit_data(self.spectrometer.intensities(), dtype='float32')
 

--- a/catkit2/services/oceanoptics_spectrometer_sim/oceanoptics_spectrometer_sim.py
+++ b/catkit2/services/oceanoptics_spectrometer_sim/oceanoptics_spectrometer_sim.py
@@ -150,16 +150,6 @@ class OceanOpticsSpectrometerSim(Service):
         '''
         self._exposure_time = exposure_time
 
-    def close(self):
-        '''
-        Close the service.
-
-        This function is called when the service is closed.
-        It close the spectrometer and cleans up the data streams.
-        '''
-        self.spectrometer.close()
-        self.spectrometer = None
-
 
 if __name__ == '__main__':
     service = OceanOpticsSpectrometerSim()

--- a/catkit2/services/oceanoptics_spectrometer_sim/oceanoptics_spectrometer_sim.py
+++ b/catkit2/services/oceanoptics_spectrometer_sim/oceanoptics_spectrometer_sim.py
@@ -95,7 +95,7 @@ class OceanOpticsSpectrometerSim(Service):
         This function is called when the service is started.
         '''
         while not self.should_shut_down:
-            intensities = self.take_one_spectrum(self.pixels_number)
+            intensities = self.take_one_spectrum()
             self.spectra.submit_data(np.array(intensities, dtype='float32'))
             self.sleep(self.interval)
 
@@ -103,7 +103,7 @@ class OceanOpticsSpectrometerSim(Service):
         '''
         Measure one spectrum and submit it to the data stream.
         '''
-        intensities = np.random.random(self.pixels_number)
+        intensities = np.random.random(self.pixels_number) + 1000
 
         self.is_saturating.submit_data(np.array([0], dtype='int8'))
 

--- a/catkit2/services/oceanoptics_spectrometer_sim/oceanoptics_spectrometer_sim.py
+++ b/catkit2/services/oceanoptics_spectrometer_sim/oceanoptics_spectrometer_sim.py
@@ -7,10 +7,7 @@ from catkit2.testbed.service import Service
 
 class OceanOpticsSpectrometerSim(Service):
     '''
-    Service for Ocean Optics Spectrometer.
-
-    This service is a wrapper around the python seabreeze package.
-    It provides a simple interface to control the spectrometer and acquire spectra.
+    Service for simulated Ocean Optics Spectrometer.
 
     Attributes
     ----------
@@ -98,8 +95,9 @@ class OceanOpticsSpectrometerSim(Service):
         '''
         while not self.should_shut_down:
             intensities = self.take_one_spectrum(self.pixels_number)
-            self.is_saturating.submit_data(np.array([0], dtype='int8'))
             self.spectra.submit_data(np.array(intensities, dtype='float32'))
+            self.is_saturating.submit_data(np.array([0], dtype='int8'))
+
             self.sleep(self.interval)
 
     def take_one_spectrum(self):
@@ -107,7 +105,7 @@ class OceanOpticsSpectrometerSim(Service):
         Measure and return one spectrum.
         Simulated service: random numpy array.
         '''
-        return np.random.random(self.pixels_number)
+        return np.random.random(self.pixels_number) + 1000
 
     @property
     def wavelengths(self):
@@ -143,7 +141,6 @@ class OceanOpticsSpectrometerSim(Service):
         ----------
         exposure_time : int
             The exposure time in microseconds.
-
         '''
         self._exposure_time = exposure_time
 

--- a/catkit2/services/oceanoptics_spectrometer_sim/oceanoptics_spectrometer_sim.py
+++ b/catkit2/services/oceanoptics_spectrometer_sim/oceanoptics_spectrometer_sim.py
@@ -2,10 +2,6 @@
 This module contains a service for simulation Ocean Optics Spectrometers.
 '''
 import numpy as np
-
-from seabreeze.spectrometers import Spectrometer
-from seabreeze.spectrometers import SeaBreezeError
-
 from catkit2.testbed.service import Service
 
 
@@ -50,7 +46,7 @@ class OceanOpticsSpectrometerSim(Service):
         '''
         Create a new OceanOpticsSpectrometer service.
         '''
-        super().__init__('oceanoptics_spectrometer)sim')
+        super().__init__('oceanoptics_spectrometer_sim')
 
         self.interval = self.config.get('interval', 1)
         self._exposure_time = self.config.get('exposure_time', 1000)

--- a/catkit2/services/oceanoptics_spectrometer_sim/oceanoptics_spectrometer_sim.py
+++ b/catkit2/services/oceanoptics_spectrometer_sim/oceanoptics_spectrometer_sim.py
@@ -50,7 +50,7 @@ class OceanOpticsSpectrometerSim(Service):
 
         self.interval = self.config.get('interval', 1)
         self._exposure_time = self.config.get('exposure_time', 1000)
-        
+
         self.pixels_number = 3000
 
         self.spectra = None

--- a/catkit2/testbed/proxies/__init__.py
+++ b/catkit2/testbed/proxies/__init__.py
@@ -7,7 +7,7 @@ __all__ = [
     'NiDaqProxy',
     'NktSuperkProxy',
     'ThorlabsCubeMotorKinesisProxy',
-    'WebPowerSwitchProxy', 
+    'WebPowerSwitchProxy',
     'OceanopticsSpectroProxy'
 ]
 

--- a/catkit2/testbed/proxies/__init__.py
+++ b/catkit2/testbed/proxies/__init__.py
@@ -7,7 +7,8 @@ __all__ = [
     'NiDaqProxy',
     'NktSuperkProxy',
     'ThorlabsCubeMotorKinesisProxy',
-    'WebPowerSwitchProxy'
+    'WebPowerSwitchProxy', 
+    'OceanopticsSpectroProxy'
 ]
 
 from .bmc_dm import *
@@ -17,5 +18,6 @@ from .flip_mount import *
 from .newport_picomotor import *
 from .ni_daq import *
 from .nkt_superk import *
+from .oceanoptics_spectrometer import *
 from .thorlabs_cube_motor_kinesis import *
 from .web_power_switch import *

--- a/catkit2/testbed/proxies/oceanoptics_spectrometer.py
+++ b/catkit2/testbed/proxies/oceanoptics_spectrometer.py
@@ -1,0 +1,22 @@
+from ..service_proxy import ServiceProxy
+
+@ServiceProxy.register_service_interface('oceanoptics_spectrometer')
+class OceanopticsSpectroProxy(ServiceProxy):
+
+    def take_raw_exposures(self, num_exposures):
+        first_frame_id = self.spectra.newest_available_frame_id
+
+        i = 0
+        num_exposures_remaining = num_exposures
+
+        while num_exposures_remaining >= 1:
+            try:
+                frame = self.spectra.get_frame(first_frame_id + i, 1000)
+            except RuntimeError:
+                # The frame wasn't available anymore because we were waiting too long.
+                continue
+            finally:
+                i += 1
+
+            yield frame.data.copy()
+            num_exposures_remaining -= 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ Catkit2
    services/newport_xps_q8
    services/ni_daq
    services/nkt_superk
+   services/oceanoptics_spectrometer
    services/omega_ithx_w3
    services/safety_monitor
    services/snmp_ups

--- a/docs/services/oceanoptics_spectrometer.rst
+++ b/docs/services/oceanoptics_spectrometer.rst
@@ -1,0 +1,42 @@
+Ocean Optics Spectrometer
+====================
+
+This service controls an Ocean Optics Spectrometer. It is a wrapper around the python-seabreeze package.
+The python-seabreeze package needs to be installed first, and the page also explain how to install the
+spectrometer drivers needed for windows.
+
+python-seabreeze package: `https://python-seabreeze.readthedocs.io/ <https://python-seabreeze.readthedocs.io/>`_
+
+The service has been successfully tested with the following ocean optics spectrometer:
+
+- USB4000 Spectrometer
+
+Configuration
+-------------
+
+.. code-block:: YAML
+
+  spectrometer:
+    service_type: oceanoptics_spectrometer
+    simulated_service_type: oceanoptics_spectrometer_sim
+    requires_safety: false
+    interface: oceanoptics_spectrometer
+
+    serial_number: USB4C01580 # Serial number of the spectrometer.
+    exposure_time: 1000       # Exposure time of the spectrometer in microseconds.
+    interval: 0.01            # Interval between measurements, in seconds.
+
+Properties
+----------
+``exposure_time``: Exposure time of the spectrometer in microseconds.
+
+``wavelengths``:  Wavelengths in (nm) corresponding to each pixel of the spectrometer
+
+Commands
+--------
+
+Datastreams
+-----------
+``spectra``: Spectra acquired by the camera.
+
+``is_saturating``: If the intensity as reach the maximum value of the spectrometer.

--- a/docs/services/oceanoptics_spectrometer.rst
+++ b/docs/services/oceanoptics_spectrometer.rst
@@ -1,5 +1,5 @@
 Ocean Optics Spectrometer
-====================
+=========================
 
 This service controls an Ocean Optics Spectrometer. It is a wrapper around the python-seabreeze package.
 The python-seabreeze package needs to be installed first, and the page also explain how to install the
@@ -19,8 +19,8 @@ Configuration
   spectrometer:
     service_type: oceanoptics_spectrometer
     simulated_service_type: oceanoptics_spectrometer_sim
-    requires_safety: false
     interface: oceanoptics_spectrometer
+    requires_safety: false
 
     serial_number: USB4C01580 # Serial number of the spectrometer.
     exposure_time: 1000       # Exposure time of the spectrometer in microseconds.
@@ -39,4 +39,4 @@ Datastreams
 -----------
 ``spectra``: Spectra acquired by the camera.
 
-``is_saturating``: If the intensity as reach the maximum value of the spectrometer.
+``is_saturating``: If the intensity as reached the maximum value of the spectrometer.

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - conda-forge::pyvisa>=1.10
   - conda-forge::pyvisa-py
   - conda-forge::nidaqmx-python
+  - conda-forge::seabreeze
   - pyserial
   - pysnmp
   - requests


### PR DESCRIPTION
Official API exists in C by Ocean optics called seabreeze: https://www.oceaninsight.com/globalassets/catalog-blocks-and-images/software-downloads-installers/javadocs-api/seabreeze/html/index.html

Good python package wrapping this API seems to be python-seabreeze
https://pypi.org/project/seabreeze/
https://github.com/ap--/python-seabreeze

Address issue in ivalaginja/thd-controls#143