### PR TITLE
Fix startup safety service upon server startup

### DIFF
--- a/catkit2/testbed/testbed.py
+++ b/catkit2/testbed/testbed.py
@@ -161,7 +161,7 @@ class Testbed:
 
         self.startup_services = []
         if 'safety' in self.config['testbed']:
-            self.startup_services.extend(self.config['testbed']['safety']['service_id'])
+            self.startup_services.append(self.config['testbed']['safety']['service_id'])
         else:
             self.log.warning('No safety service specified in the configuration file. The testbed will not be checked for safety.')
 


### PR DESCRIPTION
Extending a list with a single string would add individual chars to the list of services to be started. 

Fixes #176. 

<img width="466" alt="image" src="https://github.com/spacetelescope/catkit2/assets/59067418/c91b689c-efc7-4b57-8142-daabe64b1ed2">
