### PR TITLE
Add `miniconda-version: "latest"` to parameters of testing action

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,6 +22,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: conda-incubator/setup-miniconda@v2
       with:
+          miniconda-version: "latest"
           auto-update-conda: true
           auto-activate-base: false
     - name: Install dependencies


### PR DESCRIPTION
CI started failing on MacOS only, the error message it gives us says to do this to fix things.

<img width="1037" alt="Screenshot 2024-04-24 at 19 02 51" src="https://github.com/spacetelescope/catkit2/assets/29508965/967e802c-554c-465e-8851-bc4bde039639">
