### PR TITLE
Stop NKT emission when stopping service

### DIFF
--- a/catkit2/services/nkt_superk/nkt_superk.py
+++ b/catkit2/services/nkt_superk/nkt_superk.py
@@ -164,6 +164,9 @@ class NktSuperk(Service):
             self.sleep(1)
 
     def close(self):
+        # Turn off the source
+        self.set_emission(0)
+
         # Join all threads.
         for thread in self.threads.values():
             thread.join()

--- a/catkit2/services/nkt_superk_sim/nkt_superk_sim.py
+++ b/catkit2/services/nkt_superk_sim/nkt_superk_sim.py
@@ -65,6 +65,8 @@ class NktSuperkSim(Service):
             self.sleep(1)
 
     def close(self):
+        # Stop emission
+        self.set_emission(0)
         # Join all threads.
         for thread in self.threads.values():
             thread.join()


### PR DESCRIPTION
Just stopping the emission at the beginning of the ``close()`` method, in sim and on hardware. 

This PR fixes #198. 

- [x] Tested in simulation
- [x] Tested on hardware