### PR TITLE
Reset properties while acquisition in Allied Vision camera service

### DIFF
--- a/catkit2/services/allied_vision_camera/allied_vision_camera.py
+++ b/catkit2/services/allied_vision_camera/allied_vision_camera.py
@@ -233,19 +233,6 @@ class AlliedVisionCamera(Service):
         self.log.info('Using pixel format: %s', self.current_pixel_format)
         self.cam.set_pixel_format(self.pixel_formats[self.current_pixel_format])
 
-        # Set device values from config file (set width and height before offsets)
-        offset_x = self.config.get('offset_x', 0)
-        offset_y = self.config.get('offset_y', 0)
-
-        self.width = self.config.get('width', self.sensor_width - offset_x)
-        self.height = self.config.get('height', self.sensor_height - offset_y)
-        self.offset_x = offset_x
-        self.offset_y = offset_y
-
-        self.gain = self.config.get('gain', 0)
-        self.exposure_time = self.config.get('exposure_time', 1000)
-        self.temperature = self.make_data_stream('temperature', 'float64', [1], 20)
-
         # Create datastreams
         # Use the full sensor size here to always allocate enough shared memory.
         self.images = self.make_data_stream('images', 'float32',
@@ -260,6 +247,19 @@ class AlliedVisionCamera(Service):
                 self.make_property(name, lambda: getattr(self, name))
             else:
                 self.make_property(name, lambda: getattr(self, name), lambda val: setattr(self, name, val))
+
+        # Set device values from config file (set width and height before offsets)
+        offset_x = self.config.get('offset_x', 0)
+        offset_y = self.config.get('offset_y', 0)
+
+        self.width = self.config.get('width', self.sensor_width - offset_x)
+        self.height = self.config.get('height', self.sensor_height - offset_y)
+        self.offset_x = offset_x
+        self.offset_y = offset_y
+
+        self.gain = self.config.get('gain', 0)
+        self.exposure_time = self.config.get('exposure_time', 1000)
+        self.temperature = self.make_data_stream('temperature', 'float64', [1], 20)
 
         make_property_helper('exposure_time')
         make_property_helper('gain')

--- a/docs/services/allied_vision_camera.rst
+++ b/docs/services/allied_vision_camera.rst
@@ -3,8 +3,9 @@ Allied Vision Camera
 
 This service controls an Allied Vision camera. It is a wrapper around the Vimba SDK, which requires its installation.
 The service uses the Python API for Vimba SDK, called ``VimbaPython``.
-In order to be able to run the service on an Allied Vision Camera, the right Driver needs to be set up on the device.
-The Allied Vision Camera's driver can be changed through NI MAX.
+In order to be able to run this service, the camera needs to be set up with the right Allied Vision USB driver.
+If the device is also controlled through other interfaces, for example NI MAX, you need to switch back to the right
+driver through that interface.
 
 Vimba SDK is now superceded by Vimba X SDK. The service might be updated in the future to use the Vimba X SDK and its
 Python API ``VmbPy`` instead.

--- a/docs/services/allied_vision_camera.rst
+++ b/docs/services/allied_vision_camera.rst
@@ -3,6 +3,8 @@ Allied Vision Camera
 
 This service controls an Allied Vision camera. It is a wrapper around the Vimba SDK, which requires its installation.
 The service uses the Python API for Vimba SDK, called ``VimbaPython``.
+In order to be able to run the service on an Allied Vision Camera, the right Driver needs to be set up on the device.
+The Allied Vision Camera's driver can be changed through NI MAX.
 
 Vimba SDK is now superceded by Vimba X SDK. The service might be updated in the future to use the Vimba X SDK and its
 Python API ``VmbPy`` instead.


### PR DESCRIPTION
Fix #183.

Changing the Allied Vision Camera service so we will be able to change certain properties without having to stop the acquisition.