### PR TITLE
Fix cube motor service doc file name in index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,7 @@ Catkit2
    services/safety_monitor
    services/snmp_ups
    services/thorlabs_cld101x
-   services/thorlabs_cube_motor
+   services/thorlabs_cube_motor_kinesis
    services/thorlabs_fw102c
    services/thorlabs_mff101
    services/thorlabspm


### PR DESCRIPTION
We forgot to update it when switching from PR https://github.com/spacetelescope/catkit2/pull/170 to PR https://github.com/spacetelescope/catkit2/pull/200.