### PR TITLE
 Reset properties while acquisition in Hamamatsu camera service

### DIFF
--- a/catkit2/services/allied_vision_camera/allied_vision_camera.py
+++ b/catkit2/services/allied_vision_camera/allied_vision_camera.py
@@ -23,10 +23,10 @@ from vmbpy import (AllocationMode,
 from catkit2.testbed.service import Service
 
 
-def _create_property(property_name, read_only=False, stopped_acquisition=True):
+def _create_property(av_property_name, read_only=False, stopped_acquisition=True):
     def getter(self):
         with self.mutex:
-            return getattr(self.cam, property_name).get()
+            return getattr(self.cam, av_property_name).get()
 
     if read_only:
         setter = None
@@ -41,7 +41,7 @@ def _create_property(property_name, read_only=False, stopped_acquisition=True):
                     time.sleep(0.001)
 
             with self.mutex:
-                getattr(self.cam, property_name).set(value)
+                getattr(self.cam, av_property_name).set(value)
 
             if was_running and stopped_acquisition:
                 self.start_acquisition()

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -27,9 +27,9 @@ def _create_property(property_name, read_only=False, stopped_acquisition=True):
     def getter(self):
         with self.mutex:
             if property_name != 'EXPOSURETIME':
-                return getattr(self.cam, property_name).prop_getvalue(dcam.DCAM_IDPROP.property_name)
+                return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, property_name))
             else:
-                return getattr(self.cam, property_name).prop_getvalue(dcam.DCAM_IDPROP.property_name) * 1e6
+                return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, property_name)) * 1e6
 
     if read_only:
         setter = None
@@ -45,9 +45,9 @@ def _create_property(property_name, read_only=False, stopped_acquisition=True):
 
             with self.mutex:
                 if property_name != 'EXPOSURETIME':
-                    getattr(self.cam, property_name).prop_setvalue(dcam.DCAM_IDPROP.property_name, value)
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, property_name), value)
                 else:
-                    getattr(self.cam, property_name).prop_setvalue(dcam.DCAM_IDPROP.property_name, value / 1e6)
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, property_name), value / 1e6)
 
             if was_running and stopped_acquisition:
                 self.start_acquisition()

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -28,7 +28,7 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
         with self.mutex:
             if hamamatsu_property_name == 'EXPOSURETIME':
                 return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)) * 1e6
-            elif hamamatsu_property_name in ['IMAGE_WIDTH', 'IMAGE_HEIGHT', 'SUBARRAYHSIZE', 'SUBARRAYVSIZE', 'SUBARRAYVPOS', 'SUBARRAYHPOS']:
+            elif hamamatsu_property_name in ['SUBARRAYHSIZE', 'SUBARRAYVSIZE', 'SUBARRAYVPOS', 'SUBARRAYHPOS']:
                 return int(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
             else:
                 return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))
@@ -187,6 +187,9 @@ class HamamatsuCamera(Service):
         self.log.info('Using pixel format: %s', self.current_pixel_format)
         self.cam.prop_setvalue(dcam.DCAM_IDPROP.IMAGE_PIXELTYPE, self.pixel_formats[self.current_pixel_format])
 
+        self.sensor_width = self.config.get('sensor_width', 4096)
+        self.sensor_height = self.config.get('sensor_height', 2304)
+
         # Create datastreams
         # Use the full sensor size here to always allocate enough shared memory.
         self.images = self.make_data_stream('images', 'float32', [self.sensor_height, self.sensor_width], self.NUM_FRAMES)
@@ -210,7 +213,6 @@ class HamamatsuCamera(Service):
         self.offset_x = offset_x
         self.offset_y = offset_y
 
-        self.gain = self.config.get('gain', 0)
         self.exposure_time = self.config.get('exposure_time', 1000)
         self.temperature = self.make_data_stream('temperature', 'float64', [1], 20)
 
@@ -334,8 +336,6 @@ class HamamatsuCamera(Service):
 
     gain = _create_property('CONTRASTGAIN', read_only=True)
     brightness = _create_property('SENSITIVITY', read_only=True)
-    sensor_width = _create_property('IMAGE_WIDTH', read_only=True)
-    sensor_height = _create_property('IMAGE_HEIGHT', read_only=True)
 
     def get_temperature(self):
         """

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -188,7 +188,7 @@ class HamamatsuCamera(Service):
 
         # Create datastreams
         # Use the full sensor size here to always allocate enough shared memory.
-        self.images = self.make_data_stream('images', 'float32', [self.sensor_height, self.sensor_width], self.NUM_FRAMES)
+        self.images = self.make_data_stream('images', 'float32', [int(self.sensor_height), int(self.sensor_width)], self.NUM_FRAMES)
 
         self.is_acquiring = self.make_data_stream('is_acquiring', 'int8', [1], self.NUM_FRAMES)
         self.is_acquiring.submit_data(np.array([0], dtype='int8'))
@@ -258,7 +258,7 @@ class HamamatsuCamera(Service):
         # Make sure the data stream has the right size and datatype.
         has_correct_parameters = np.allclose(self.images.shape, [self.height, self.width])
         if not has_correct_parameters:
-            self.images.update_parameters('float32', [self.height, self.width], self.NUM_FRAMES)
+            self.images.update_parameters('float32', [int(self.height), int(self.width)], self.NUM_FRAMES)
 
         # Start acquisition.
         if self.cam.buf_alloc(self.NUM_FRAMES) is False:

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -48,8 +48,6 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
             with self.mutex:
                 if hamamatsu_property_name == 'EXPOSURETIME':
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value / 1e6)
-                elif hamamatsu_property_name in ['IMAGE_WIDTH', 'IMAGE_HEIGHT', 'SUBARRAYHSIZE', 'SUBARRAYVSIZE', 'SUBARRAYVPOS', 'SUBARRAYHPOS']:
-                    int(self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value))
                 else:
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value)
             if was_running and stopped_acquisition:

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -49,7 +49,7 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
                 if hamamatsu_property_name == 'EXPOSURETIME':
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value / 1e6)
                 elif hamamatsu_property_name in ['IMAGE_WIDTH', 'IMAGE_HEIGHT', 'SUBARRAYHSIZE', 'SUBARRAYVSIZE', 'SUBARRAYVPOS', 'SUBARRAYHPOS']:
-                    return int(self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value))
+                    int(self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value))
                 else:
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value)
             if was_running and stopped_acquisition:

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -214,14 +214,14 @@ class HamamatsuCamera(Service):
         self.temperature = self.make_data_stream('temperature', 'float64', [1], 20)
 
         make_property_helper('exposure_time')
-        make_property_helper('gain')
-        make_property_helper('brightness')
 
         make_property_helper('width')
         make_property_helper('height')
         make_property_helper('offset_x')
         make_property_helper('offset_y')
 
+        make_property_helper('gain', read_only=True)
+        make_property_helper('brightness', read_only=True)
         make_property_helper('sensor_width', read_only=True)
         make_property_helper('sensor_height', read_only=True)
 
@@ -325,14 +325,15 @@ class HamamatsuCamera(Service):
         self.should_be_acquiring.clear()
 
     exposure_time = _create_property('EXPOSURETIME', stopped_acquisition=False)
-    gain = _create_property('CONTRASTGAIN', stopped_acquisition=False)
-    brightness = _create_property('SENSITIVITY', stopped_acquisition=False)
+
 
     width = _create_property('SUBARRAYHSIZE')
     height = _create_property('SUBARRAYVSIZE')
     offset_x = _create_property('SUBARRAYVPOS')
     offset_y = _create_property('SUBARRAYHPOS')
 
+    gain = _create_property('CONTRASTGAIN', read_only=True)
+    brightness = _create_property('SENSITIVITY', read_only=True)
     sensor_width = _create_property('IMAGE_WIDTH', read_only=True)
     sensor_height = _create_property('IMAGE_HEIGHT', read_only=True)
 

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -134,6 +134,7 @@ class HamamatsuCamera(Service):
         if self.cam.dev_open() is False:
             raise RuntimeError(f'Dcam.dev_open() fails with error {self.cam.lasterr()}')
 
+        # Read ROI of full sensor before ROI is adapted.
         self.sensor_width = int(self.cam.prop_getvalue(dcam.DCAM_IDPROP.IMAGE_WIDTH))
         self.sensor_height = int(self.cam.prop_getvalue(dcam.DCAM_IDPROP.IMAGE_HEIGHT))
 

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -134,6 +134,9 @@ class HamamatsuCamera(Service):
         if self.cam.dev_open() is False:
             raise RuntimeError(f'Dcam.dev_open() fails with error {self.cam.lasterr()}')
 
+        self.sensor_width = int(self.cam.prop_getvalue(dcam.DCAM_IDPROP.IMAGE_WIDTH))
+        self.sensor_height = int(self.cam.prop_getvalue(dcam.DCAM_IDPROP.IMAGE_HEIGHT))
+
         # Set water cooling mode and fan mode
         self.cooling_mode = self.config.get('cooling_mode', 'on')
         self.fan_on = self.config.get('fan_on', True)
@@ -186,9 +189,6 @@ class HamamatsuCamera(Service):
             raise ValueError(f'Invalid pixel format: {self.current_pixel_format}, must be one of {str(list(self.pixel_formats.keys()))}')
         self.log.info('Using pixel format: %s', self.current_pixel_format)
         self.cam.prop_setvalue(dcam.DCAM_IDPROP.IMAGE_PIXELTYPE, self.pixel_formats[self.current_pixel_format])
-
-        self.sensor_width = self.config.get('sensor_width', 4096)
-        self.sensor_height = self.config.get('sensor_height', 2304)
 
         # Create datastreams
         # Use the full sensor size here to always allocate enough shared memory.

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -7,6 +7,7 @@ It provides a simple interface to control the camera and acquire images.
 import os
 import sys
 import threading
+import time
 import numpy as np
 from catkit2.testbed.service import Service
 from catkit2.testbed.tracing import trace_interval
@@ -20,6 +21,32 @@ try:
 except ImportError:
     print('To use Hamamatsu cameras, you need to set the CATKIT_DCAM_SDK_PATH environment variable.')
     raise
+
+
+def _create_property(property_name, read_only=False, stopped_acquisition=True):
+    def getter(self):
+        with self.mutex:
+            return getattr(self.cam, property_name).prop_getvalue(dcam.DCAM_IDPROP.property_name)
+
+    if read_only:
+        setter = None
+    else:
+        def setter(self, value):
+            was_running = self.is_acquiring.get()[0] > 0
+
+            if was_running and stopped_acquisition:
+                self.end_acquisition()
+
+                while self.is_acquiring.get()[0]:
+                    time.sleep(0.001)
+
+            with self.mutex:
+                getattr(self.cam, property_name).prop_setvalue(dcam.DCAM_IDPROP.property_name, value)
+
+            if was_running and stopped_acquisition:
+                self.start_acquisition()
+
+    return property(getter, setter)
 
 
 class HamamatsuCamera(Service):
@@ -73,6 +100,9 @@ class HamamatsuCamera(Service):
 
         self.should_be_acquiring = threading.Event()
         self.should_be_acquiring.set()
+
+        # Create lock for camera access
+        self.mutex = threading.Lock()
 
     def open(self):
         """
@@ -150,19 +180,6 @@ class HamamatsuCamera(Service):
         self.log.info('Using pixel format: %s', self.current_pixel_format)
         self.cam.prop_setvalue(dcam.DCAM_IDPROP.IMAGE_PIXELTYPE, self.pixel_formats[self.current_pixel_format])
 
-        # Set device values from config file (set width and height before offsets)
-        offset_x = self.config.get('offset_x', 0)
-        offset_y = self.config.get('offset_y', 0)
-
-        self.width = self.config.get('width', self.sensor_width - offset_x)
-        self.height = self.config.get('height', self.sensor_height - offset_y)
-        self.offset_x = offset_x
-        self.offset_y = offset_y
-
-        self.gain = self.config.get('gain', 0)
-        self.exposure_time = self.config.get('exposure_time', 1000)
-        self.temperature = self.make_data_stream('temperature', 'float64', [1], 20)
-
         # Create datastreams
         # Use the full sensor size here to always allocate enough shared memory.
         self.images = self.make_data_stream('images', 'float32', [self.sensor_height, self.sensor_width], self.NUM_FRAMES)
@@ -176,6 +193,19 @@ class HamamatsuCamera(Service):
                 self.make_property(name, lambda: getattr(self, name))
             else:
                 self.make_property(name, lambda: getattr(self, name), lambda val: setattr(self, name, val))
+
+        # Set device values from config file (set width and height before offsets)
+        offset_x = self.config.get('offset_x', 0)
+        offset_y = self.config.get('offset_y', 0)
+
+        self.width = self.config.get('width', self.sensor_width - offset_x)
+        self.height = self.config.get('height', self.sensor_height - offset_y)
+        self.offset_x = offset_x
+        self.offset_y = offset_y
+
+        self.gain = self.config.get('gain', 0)
+        self.exposure_time = self.config.get('exposure_time', 1000)
+        self.temperature = self.make_data_stream('temperature', 'float64', [1], 20)
 
         make_property_helper('exposure_time')
         make_property_helper('gain')
@@ -288,6 +318,18 @@ class HamamatsuCamera(Service):
         """
         self.should_be_acquiring.clear()
 
+     # exposure_time = _create_property('EXPOSURETIME', stopped_acquisition=False) * 1e6
+    gain = _create_property('CONTRASTGAIN', stopped_acquisition=False)
+    brightness = _create_property('SENSITIVITY', stopped_acquisition=False)
+
+    width = _create_property('SUBARRAYHSIZE')
+    height = _create_property('SUBARRAYVSIZE')
+    offset_x = _create_property('SUBARRAYVPOS')
+    offset_y = _create_property('SUBARRAYHPOS')
+
+    sensor_width = _create_property('IMAGE_WIDTH', read_only=True)
+    sensor_height = _create_property('IMAGE_HEIGHT', read_only=True)
+
     def get_temperature(self):
         """
         Get the temperature of the camera.
@@ -328,202 +370,6 @@ class HamamatsuCamera(Service):
             The exposure time in microseconds.
         """
         self.cam.prop_setvalue(dcam.DCAM_IDPROP.EXPOSURETIME, exposure_time / 1e6)
-
-    @property
-    def gain(self):
-        """
-        The gain of the camera.
-
-        This property can be used to get the gain of the camera.
-
-        Returns:
-        --------
-        int:
-            The gain of the camera.
-        """
-        return self.cam.prop_getvalue(dcam.DCAM_IDPROP.CONTRASTGAIN)
-
-    @gain.setter
-    def gain(self, gain: int):
-        """
-        Set the gain of the camera.
-
-        This property can be used to set the gain of the camera.
-
-        Parameters
-        ----------
-        gain : int
-            The gain of the camera.
-        """
-        self.cam.prop_setvalue(dcam.DCAM_IDPROP.CONTRASTGAIN, gain)
-
-    @property
-    def brightness(self):
-        """
-        The brightness of the camera.
-
-        This property can be used to get the brightness of the camera.
-
-        Returns:
-        --------
-        int:
-            The brightness of the camera.
-        """
-        return self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSITIVITY)
-
-    @brightness.setter
-    def brightness(self, brightness: int):
-        """
-        Set the brightness of the camera.
-
-        This property can be used to set the brightness of the camera.
-
-        Parameters
-        ----------
-        brightness : int
-            The brightness of the camera.
-        """
-        self.cam.prop_setvalue(dcam.DCAM_IDPROP.SENSITIVITY, brightness)
-
-    @property
-    def sensor_width(self):
-        """
-        The width of the sensor in pixels.
-
-        This property can be used to get the width of the sensor in pixels.
-
-        Returns:
-        --------
-        int:
-            The width of the sensor in pixels.
-        """
-        return int(self.cam.prop_getvalue(dcam.DCAM_IDPROP.IMAGE_WIDTH))
-
-    @property
-    def sensor_height(self):
-        """
-        The height of the sensor in pixels.
-
-        This property can be used to get the height of the sensor in pixels.
-
-        Returns:
-        --------
-        int:
-            The height of the sensor in pixels.
-        """
-        return int(self.cam.prop_getvalue(dcam.DCAM_IDPROP.IMAGE_HEIGHT))
-
-    @property
-    def width(self):
-        """
-        The width of the image in pixels.
-
-        This property can be used to get the width of the image in pixels.
-
-        Returns:
-        --------
-        int:
-            The width of the image in pixels.
-        """
-        return int(self.cam.prop_getvalue(dcam.DCAM_IDPROP.SUBARRAYHSIZE))
-
-    @width.setter
-    def width(self, width: int):
-        """
-        Set the width of the image in pixels.
-
-        This property can be used to set the width of the image in pixels.
-
-        Parameters
-        ----------
-        width : int
-            The width of the image in pixels.
-        """
-        self.cam.prop_setvalue(dcam.DCAM_IDPROP.SUBARRAYHSIZE, width)
-
-    @property
-    def height(self):
-        """
-        The height of the image in pixels.
-
-        This property can be used to get the height of the image in pixels.
-
-        Returns:
-        --------
-        int:
-            The height of the image in pixels.
-        """
-        return int(self.cam.prop_getvalue(dcam.DCAM_IDPROP.SUBARRAYVSIZE))
-
-    @height.setter
-    def height(self, height: int):
-        """
-        Set the height of the image in pixels.
-
-        This property can be used to set the height of the image in pixels.
-
-        Parameters
-        ----------
-        height : int
-            The height of the image in pixels.
-        """
-        self.cam.prop_setvalue(dcam.DCAM_IDPROP.SUBARRAYVSIZE, height)
-
-    @property
-    def offset_x(self):
-        """
-        The x offset of the image in pixels.
-
-        This property can be used to get the x offset of the image in pixels.
-
-        Returns:
-        --------
-        int:
-            The x offset of the image in pixels.
-        """
-        return self.cam.prop_getvalue(dcam.DCAM_IDPROP.SUBARRAYVPOS)
-
-    @offset_x.setter
-    def offset_x(self, offset_x: int):
-        """
-        Set the x offset of the image in pixels.
-
-        This property can be used to set the x offset of the image in pixels.
-
-        Parameters
-        ----------
-        offset_x : int
-            The x offset of the image in pixels.
-        """
-        self.cam.prop_setvalue(dcam.DCAM_IDPROP.SUBARRAYVPOS, offset_x)
-
-    @property
-    def offset_y(self):
-        """
-        The y offset of the image in pixels.
-
-        This property can be used to get the y offset of the image in pixels.
-
-        Returns:
-        --------
-        int:
-            The y offset of the image in pixels.
-        """
-        return self.cam.prop_getvalue(dcam.DCAM_IDPROP.SUBARRAYHPOS)
-
-    @offset_y.setter
-    def offset_y(self, offset_y: int):
-        """
-        Set the y offset of the image in pixels.
-
-        This property can be used to set the y offset of the image in pixels.
-
-        Parameters
-        ----------
-        offset_y : int
-            The y offset of the image in pixels.
-        """
-        self.cam.prop_setvalue(dcam.DCAM_IDPROP.SUBARRAYHPOS, offset_y)
 
 
 if __name__ == '__main__':

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -23,13 +23,13 @@ except ImportError:
     raise
 
 
-def _create_property(property_name, read_only=False, stopped_acquisition=True):
+def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisition=True):
     def getter(self):
         with self.mutex:
-            if property_name != 'EXPOSURETIME':
-                return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, property_name))
+            if hamamatsu_property_name != 'EXPOSURETIME':
+                return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))
             else:
-                return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, property_name)) * 1e6
+                return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)) * 1e6
 
     if read_only:
         setter = None
@@ -44,10 +44,10 @@ def _create_property(property_name, read_only=False, stopped_acquisition=True):
                     time.sleep(0.001)
 
             with self.mutex:
-                if property_name != 'EXPOSURETIME':
-                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, property_name), value)
+                if hamamatsu_property_name != 'EXPOSURETIME':
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value)
                 else:
-                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, property_name), value / 1e6)
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value / 1e6)
 
             if was_running and stopped_acquisition:
                 self.start_acquisition()

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -26,10 +26,12 @@ except ImportError:
 def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisition=True):
     def getter(self):
         with self.mutex:
-            if hamamatsu_property_name != 'EXPOSURETIME':
-                return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))
-            else:
+            if hamamatsu_property_name == 'EXPOSURETIME':
                 return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)) * 1e6
+            elif hamamatsu_property_name in ['IMAGE_WIDTH', 'IMAGE_HEIGHT', 'SUBARRAYHSIZE', 'SUBARRAYVSIZE', 'SUBARRAYVPOS', 'SUBARRAYHPOS']:
+                return int(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
+            else:
+                return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))
 
     if read_only:
         setter = None
@@ -44,11 +46,12 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
                     time.sleep(0.001)
 
             with self.mutex:
-                if hamamatsu_property_name != 'EXPOSURETIME':
-                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value)
-                else:
+                if hamamatsu_property_name == 'EXPOSURETIME':
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value / 1e6)
-
+                elif hamamatsu_property_name in ['IMAGE_WIDTH', 'IMAGE_HEIGHT', 'SUBARRAYHSIZE', 'SUBARRAYVSIZE', 'SUBARRAYVPOS', 'SUBARRAYHPOS']:
+                    return int(self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value))
+                else:
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value)
             if was_running and stopped_acquisition:
                 self.start_acquisition()
 
@@ -188,7 +191,7 @@ class HamamatsuCamera(Service):
 
         # Create datastreams
         # Use the full sensor size here to always allocate enough shared memory.
-        self.images = self.make_data_stream('images', 'float32', [int(self.sensor_height), int(self.sensor_width)], self.NUM_FRAMES)
+        self.images = self.make_data_stream('images', 'float32', [self.sensor_height, self.sensor_width], self.NUM_FRAMES)
 
         self.is_acquiring = self.make_data_stream('is_acquiring', 'int8', [1], self.NUM_FRAMES)
         self.is_acquiring.submit_data(np.array([0], dtype='int8'))
@@ -258,7 +261,7 @@ class HamamatsuCamera(Service):
         # Make sure the data stream has the right size and datatype.
         has_correct_parameters = np.allclose(self.images.shape, [self.height, self.width])
         if not has_correct_parameters:
-            self.images.update_parameters('float32', [int(self.height), int(self.width)], self.NUM_FRAMES)
+            self.images.update_parameters('float32', [self.height, self.width], self.NUM_FRAMES)
 
         # Start acquisition.
         if self.cam.buf_alloc(self.NUM_FRAMES) is False:
@@ -325,7 +328,6 @@ class HamamatsuCamera(Service):
         self.should_be_acquiring.clear()
 
     exposure_time = _create_property('EXPOSURETIME', stopped_acquisition=False)
-
 
     width = _create_property('SUBARRAYHSIZE')
     height = _create_property('SUBARRAYVSIZE')

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -26,7 +26,10 @@ except ImportError:
 def _create_property(property_name, read_only=False, stopped_acquisition=True):
     def getter(self):
         with self.mutex:
-            return getattr(self.cam, property_name).prop_getvalue(dcam.DCAM_IDPROP.property_name)
+            if property_name != 'EXPOSURETIME':
+                return getattr(self.cam, property_name).prop_getvalue(dcam.DCAM_IDPROP.property_name)
+            else:
+                return getattr(self.cam, property_name).prop_getvalue(dcam.DCAM_IDPROP.property_name) * 1e6
 
     if read_only:
         setter = None
@@ -41,7 +44,10 @@ def _create_property(property_name, read_only=False, stopped_acquisition=True):
                     time.sleep(0.001)
 
             with self.mutex:
-                getattr(self.cam, property_name).prop_setvalue(dcam.DCAM_IDPROP.property_name, value)
+                if property_name != 'EXPOSURETIME':
+                    getattr(self.cam, property_name).prop_setvalue(dcam.DCAM_IDPROP.property_name, value)
+                else:
+                    getattr(self.cam, property_name).prop_setvalue(dcam.DCAM_IDPROP.property_name, value / 1e6)
 
             if was_running and stopped_acquisition:
                 self.start_acquisition()
@@ -318,7 +324,7 @@ class HamamatsuCamera(Service):
         """
         self.should_be_acquiring.clear()
 
-     # exposure_time = _create_property('EXPOSURETIME', stopped_acquisition=False) * 1e6
+    exposure_time = _create_property('EXPOSURETIME', stopped_acquisition=False)
     gain = _create_property('CONTRASTGAIN', stopped_acquisition=False)
     brightness = _create_property('SENSITIVITY', stopped_acquisition=False)
 
@@ -342,34 +348,6 @@ class HamamatsuCamera(Service):
             The temperature of the camera in degrees Celsius.
         """
         return self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSORTEMPERATURE)
-
-    @property
-    def exposure_time(self):
-        """
-        The exposure time in microseconds.
-
-        This property can be used to get the exposure time of the camera.
-
-        Returns:
-        --------
-        float:
-            The exposure time in microseconds.
-        """
-        return self.cam.prop_getvalue(dcam.DCAM_IDPROP.EXPOSURETIME) * 1e6
-
-    @exposure_time.setter
-    def exposure_time(self, exposure_time: float):
-        """
-        Set the exposure time in microseconds.
-
-        This property can be used to set the exposure time of the camera.
-
-        Parameters
-        ----------
-        exposure_time : float
-            The exposure time in microseconds.
-        """
-        self.cam.prop_setvalue(dcam.DCAM_IDPROP.EXPOSURETIME, exposure_time / 1e6)
 
 
 if __name__ == '__main__':

--- a/docs/services/hamamatsu_camera.rst
+++ b/docs/services/hamamatsu_camera.rst
@@ -42,13 +42,13 @@ Properties
 ----------
 ``exposure_time``: Exposure time of the camera in microseconds.
 
-``width``: The width of the camera frames.
+``width``: The width of the camera frames (integer factor of 4).
 
-``height``: The height of the camera frames.
+``height``: The height of the camera frames (integer factor of 4).
 
-``offset_x``: The x offset of the camera frames on the sensor.
+``offset_x``: The x offset of the camera frames on the sensor (integer factor of 4).
 
-``offset_y``: The y offset of the camera frames on the sensor.
+``offset_y``: The y offset of the camera frames on the sensor (integer factor of 4).
 
 ``sensor_width``: The width of the sensor.
 

--- a/docs/services/hamamatsu_camera.rst
+++ b/docs/services/hamamatsu_camera.rst
@@ -42,17 +42,17 @@ Properties
 ----------
 ``exposure_time``: Exposure time of the camera in microseconds.
 
-``width``: The width of the camera frames (int).
+``width``: The width of the camera frames.
 
-``height``: The height of the camera frames (int).
+``height``: The height of the camera frames.
 
-``offset_x``: The x offset of the camera frames on the sensor (int).
+``offset_x``: The x offset of the camera frames on the sensor.
 
-``offset_y``: The y offset of the camera frames on the sensor (int).
+``offset_y``: The y offset of the camera frames on the sensor.
 
-``sensor_width``: The width of the sensor (int).
+``sensor_width``: The width of the sensor.
 
-``sensor_height``: The height of the sensor (int).
+``sensor_height``: The height of the sensor.
 
 Commands
 --------

--- a/docs/services/hamamatsu_camera.rst
+++ b/docs/services/hamamatsu_camera.rst
@@ -34,8 +34,6 @@ Configuration
       offset_y: 0
       width: 400
       height: 400
-      sensor_width: 4096
-      sensor_height: 2304
       exposure_time: 8294.4
 
 Properties

--- a/docs/services/hamamatsu_camera.rst
+++ b/docs/services/hamamatsu_camera.rst
@@ -37,27 +37,22 @@ Configuration
       sensor_width: 4096
       sensor_height: 2304
       exposure_time: 8294.4
-      gain: 0
 
 Properties
 ----------
 ``exposure_time``: Exposure time of the camera in microseconds.
 
-``gain``: Gain of the camera.
+``width``: The width of the camera frames (int).
 
-``brightness``: Brightness of the camera.
+``height``: The height of the camera frames (int).
 
-``width``: The width of the camera frames.
+``offset_x``: The x offset of the camera frames on the sensor (int).
 
-``height``: The height of the camera frames.
+``offset_y``: The y offset of the camera frames on the sensor (int).
 
-``offset_x``: The x offset of the camera frames on the sensor.
+``sensor_width``: The width of the sensor (int).
 
-``offset_y``: The y offset of the camera frames on the sensor.
-
-``sensor_width``: The width of the sensor.
-
-``sensor_height``: The height of the sensor.
+``sensor_height``: The height of the sensor (int).
 
 Commands
 --------


### PR DESCRIPTION
Fixes #194.

Changing the Hamamatsu Camera service so we will be able to change certain properties without having to stop the acquisition.