### PR TITLE
Add informations about needing to create an environment variable in the Thorlabs Cubes service doc

### DIFF
--- a/docs/services/thorlabs_cube_motor_kinesis.rst
+++ b/docs/services/thorlabs_cube_motor_kinesis.rst
@@ -7,6 +7,7 @@ This service uses bits of the official vendor Python library:
 https://github.com/Thorlabs/Motion_Control_Examples/tree/main/Python
 The service also requires the installation of the Thorlabs Kinesis software:
 https://www.thorlabs.com/software_pages/viewsoftwarepage.cfm?code=Motion_Control#
+Then, to use Thorlabs cube motors with Kinesis, you need to set the THORLABS_KINESIS_DLL_PATH environment variable.
 
 Successfully tested with the following devices:
 

--- a/docs/services/thorlabs_cube_motor_kinesis.rst
+++ b/docs/services/thorlabs_cube_motor_kinesis.rst
@@ -3,7 +3,7 @@ Thorlabs Cube Motors
 
 This service connects to Thorlabs TDC001 and Thorlabs KDC101 controllers in order to operate a motor.
 
-This service uses bits of the official vendor Python library:
+| This service uses bits of the official vendor Python library:
 `https://github.com/Thorlabs/Motion_Control_Examples/tree/main/Python <https://github.com/Thorlabs/Motion_Control_Examples/tree/main/Python>`_
 | The service also requires the installation of the Thorlabs Kinesis software:
 `https://www.thorlabs.com/software_pages/viewsoftwarepage.cfm?code=Motion_Control# <https://www.thorlabs.com/software_pages/viewsoftwarepage.cfm?code=Motion_Control#>`_

--- a/docs/services/thorlabs_cube_motor_kinesis.rst
+++ b/docs/services/thorlabs_cube_motor_kinesis.rst
@@ -4,10 +4,10 @@ Thorlabs Cube Motors
 This service connects to Thorlabs TDC001 and Thorlabs KDC101 controllers in order to operate a motor.
 
 This service uses bits of the official vendor Python library:
-https://github.com/Thorlabs/Motion_Control_Examples/tree/main/Python
-The service also requires the installation of the Thorlabs Kinesis software:
-https://www.thorlabs.com/software_pages/viewsoftwarepage.cfm?code=Motion_Control#
-Then, to use Thorlabs cube motors with Kinesis, you need to set the THORLABS_KINESIS_DLL_PATH environment variable.
+`https://github.com/Thorlabs/Motion_Control_Examples/tree/main/Python <https://github.com/Thorlabs/Motion_Control_Examples/tree/main/Python>`_
+| The service also requires the installation of the Thorlabs Kinesis software:
+`https://www.thorlabs.com/software_pages/viewsoftwarepage.cfm?code=Motion_Control# <https://www.thorlabs.com/software_pages/viewsoftwarepage.cfm?code=Motion_Control#>`_
+| Then, to use Thorlabs cube motors with Kinesis, you need to set the ``THORLABS_KINESIS_DLL_PATH`` environment variable.
 
 Successfully tested with the following devices:
 

--- a/docs/services/thorlabs_cube_motor_kinesis.rst
+++ b/docs/services/thorlabs_cube_motor_kinesis.rst
@@ -4,9 +4,9 @@ Thorlabs Cube Motors
 This service connects to Thorlabs TDC001 and Thorlabs KDC101 controllers in order to operate a motor.
 
 | This service uses bits of the official vendor Python library:
-`https://github.com/Thorlabs/Motion_Control_Examples/tree/main/Python <https://github.com/Thorlabs/Motion_Control_Examples/tree/main/Python>`_
+| `https://github.com/Thorlabs/Motion_Control_Examples/tree/main/Python <https://github.com/Thorlabs/Motion_Control_Examples/tree/main/Python>`_
 | The service also requires the installation of the Thorlabs Kinesis software:
-`https://www.thorlabs.com/software_pages/viewsoftwarepage.cfm?code=Motion_Control# <https://www.thorlabs.com/software_pages/viewsoftwarepage.cfm?code=Motion_Control#>`_
+| `https://www.thorlabs.com/software_pages/viewsoftwarepage.cfm?code=Motion_Control# <https://www.thorlabs.com/software_pages/viewsoftwarepage.cfm?code=Motion_Control#>`_
 | Then, to use Thorlabs cube motors with Kinesis, you need to set the ``THORLABS_KINESIS_DLL_PATH`` environment variable.
 
 Successfully tested with the following devices:


### PR DESCRIPTION
Add informations about the envrionnement variable THORLABS_KINESIS_DLL_PATH that needs to be created in order to be able to use Thorlabs motors with Kinesis in the thorlabs_cube_motor_kinesis service.