### PR TITLE
Fix Thorlabs Cube motors size of serial number's list

### DIFF
--- a/catkit2/services/thorlabs_cube_motor_kinesis/thorlabs_cube_motor_kinesis.py
+++ b/catkit2/services/thorlabs_cube_motor_kinesis/thorlabs_cube_motor_kinesis.py
@@ -90,7 +90,7 @@ class ThorlabsCubeMotorKinesis(Service):
         if self.lib.TLI_BuildDeviceList() == 0:
             # The serial_number_list_size is the size of a list that holds the cubes' serial numbers of one motor type.
             # This allocates a number of Bytes to store the serial numbers.
-            # Number of motors * 8 (size in Bytes of one serial motor) + Number of motors * 1 (for a comma between each serial number)
+            # Number of motors * 8 (size in bytes of one serial number) + Number of motors * 1 (bytes for commas between all serial numbers)
             serial_number_list_size = 1024    # can hold more than 100 motor serial numbers, as 100 * (8 + 1) = 900
             serial_number_list = create_string_buffer(serial_number_list_size)
             self.lib.TLI_GetDeviceListByTypeExt(serial_number_list, serial_number_list_size, self.motor_type)

--- a/catkit2/services/thorlabs_cube_motor_kinesis/thorlabs_cube_motor_kinesis.py
+++ b/catkit2/services/thorlabs_cube_motor_kinesis/thorlabs_cube_motor_kinesis.py
@@ -88,7 +88,11 @@ class ThorlabsCubeMotorKinesis(Service):
         """
         # Build the device list and verify that the device is connected.
         if self.lib.TLI_BuildDeviceList() == 0:
-            serial_number_list_size = 35  # 4 * 8 (SN size) + 3 for the commas between the serial numbers
+            # The serial_number_list_size is the size of a list that holds the cubes' serial numbers.
+            # This allocates a number of Bytes to store the serial numbers.
+            # Number of motors * 8 (size in Bytes of one serial motor)
+            # + Number of motors * 1 (for a comma between each serial number)
+            serial_number_list_size = 1024    # can hold more than 100 motors
             serial_number_list = create_string_buffer(serial_number_list_size)
             self.lib.TLI_GetDeviceListByTypeExt(serial_number_list, serial_number_list_size, self.motor_type)
             self.log.debug("Serial number: %s", self.serial_number)

--- a/catkit2/services/thorlabs_cube_motor_kinesis/thorlabs_cube_motor_kinesis.py
+++ b/catkit2/services/thorlabs_cube_motor_kinesis/thorlabs_cube_motor_kinesis.py
@@ -86,13 +86,12 @@ class ThorlabsCubeMotorKinesis(Service):
 
         This will also check if the configured characteristics are matching the one the cube has.
         """
-        # Build the device list and verify that the device is connected.
+        # Build the device list and verify that the requested device is connected.
         if self.lib.TLI_BuildDeviceList() == 0:
-            # The serial_number_list_size is the size of a list that holds the cubes' serial numbers.
+            # The serial_number_list_size is the size of a list that holds the cubes' serial numbers of one motor type.
             # This allocates a number of Bytes to store the serial numbers.
-            # Number of motors * 8 (size in Bytes of one serial motor)
-            # + Number of motors * 1 (for a comma between each serial number)
-            serial_number_list_size = 1024    # can hold more than 100 motors
+            # Number of motors * 8 (size in Bytes of one serial motor) + Number of motors * 1 (for a comma between each serial number)
+            serial_number_list_size = 1024    # can hold more than 100 motor serial numbers, as 100 * (8 + 1) = 900
             serial_number_list = create_string_buffer(serial_number_list_size)
             self.lib.TLI_GetDeviceListByTypeExt(serial_number_list, serial_number_list_size, self.motor_type)
             self.log.debug("Serial number: %s", self.serial_number)


### PR DESCRIPTION
This fixes a problem we had : the serial number's list was only able to hold a certain number of serial number.
We need to increase this size in order to be able to control more motors and cubes through the service. 
