### PR TITLE
Service docs work (Steiger)

### DIFF
--- a/catkit2/services/camera_sim/camera_sim.py
+++ b/catkit2/services/camera_sim/camera_sim.py
@@ -4,40 +4,6 @@ import threading
 import numpy as np
 
 class CameraSim(Service):
-    '''
-    Service for simulated cameras.
-
-    It provides a simple interface to simulate the controlling of a camera and
-    the acquisition of images.
-
-    Attributes
-    ----------
-    temperature : DataStream
-        A data stream to submit the temperature of the camera.
-    images : DataStream
-        A data stream to submit the images from the camera.
-    is_acquiring : DataStream
-        A data stream to submit whether the camera is currently acquiring images.
-    should_be_acquiring : threading.Event
-        An event to signal whether the camera should be acquiring images.
-    NUM_FRAMES_IN_BUFFER : int
-        The number of frames to allocate for the data streams.
-
-    Methods
-    -------
-    open()
-        Open the service.
-    main()
-        The main function of the service.
-    acquisition_loop()
-        The main acquisition loop.
-    start_acquisition()
-        Start the acquisition loop.
-    end_acquisition()
-        End the acquisition loop.
-    restart_acquisition_if_acquiring()
-        If already acquiring, restarts the acquisition.
-    '''
     NUM_FRAMES_IN_BUFFER = 20
 
     def __init__(self):

--- a/catkit2/services/camera_sim/camera_sim.py
+++ b/catkit2/services/camera_sim/camera_sim.py
@@ -4,6 +4,40 @@ import threading
 import numpy as np
 
 class CameraSim(Service):
+    '''
+    Service for simulated cameras.
+
+    It provides a simple interface to simulate the controlling of a camera and
+    the acquisition of images.
+
+    Attributes
+    ----------
+    temperature : DataStream
+        A data stream to submit the temperature of the camera.
+    images : DataStream
+        A data stream to submit the images from the camera.
+    is_acquiring : DataStream
+        A data stream to submit whether the camera is currently acquiring images.
+    should_be_acquiring : threading.Event
+        An event to signal whether the camera should be acquiring images.
+    NUM_FRAMES_IN_BUFFER : int
+        The number of frames to allocate for the data streams.
+
+    Methods
+    -------
+    open()
+        Open the service.
+    main()
+        The main function of the service.
+    acquisition_loop()
+        The main acquisition loop.
+    start_acquisition()
+        Start the acquisition loop.
+    end_acquisition()
+        End the acquisition loop.
+    restart_acquisition_if_acquiring()
+        If already acquiring, restarts the acquisition.
+    '''
     NUM_FRAMES_IN_BUFFER = 20
 
     def __init__(self):

--- a/docs/services/bmc_dm.rst
+++ b/docs/services/bmc_dm.rst
@@ -45,6 +45,8 @@ Properties
 Commands
 --------
 
+None.
+
 Datastreams
 -----------
 ``total_voltage``: Map of the total voltage applied to each actuator of the DM.

--- a/docs/services/bmc_dm.rst
+++ b/docs/services/bmc_dm.rst
@@ -3,6 +3,26 @@ Boston Deformable Mirror
 
 Configuration
 -------------
+.. code-block:: YAML
+
+    boston_dm1:
+        inclination:
+          design: 0
+          calibrated:
+        clocking:
+          design: 0
+          calibrated:
+        actuator_pitch: 150.0e-6
+        num_actuators_across: 48
+        reflective_diameter: 100.0e-3
+        include_actuator_print_through: false
+        max_volts: 200
+        active_actuator_mask: !path "../data/boston/rst_dm_2Dmask.fits"
+        actuator_influence_function: !path "../data/boston/boston_actuator_for_rst48.fits"
+        actuator_print_through: !path "../data/boston/boston_mems_actuator_medres.fits"
+        flat_map_voltage: !path "../data/boston/flat_map_volts_rst48.fits"
+        meter_per_volt_map: !path "../data/boston/gain_map_rst48.fits"
+        zero_padding_factor: 2  # 0 indicates no zero-padding.
 
 Properties
 ----------

--- a/docs/services/bmc_dm.rst
+++ b/docs/services/bmc_dm.rst
@@ -40,7 +40,7 @@ Configuration
 
 Properties
 ----------
-``channels``: List of command channel names (strings).
+``channels``: List of command channel names (dict).
 
 Commands
 --------
@@ -53,5 +53,4 @@ Datastreams
 
 ``total_surface``: Map of the total amplitude of each DM actuator (meters).
 
-``channel_name``: Name of the DM channel being commanded.
-
+``channels[channel_name]``: The command per virtual channel, identified by channel name.

--- a/docs/services/bmc_dm.rst
+++ b/docs/services/bmc_dm.rst
@@ -49,8 +49,8 @@ None.
 
 Datastreams
 -----------
-``total_voltage``: Map of the total voltage applied to each actuator of the DM.
+``total_voltage``: Array of the total voltage applied to each actuator of the DM.
 
-``total_surface``: Map of the total amplitude of each DM actuator (meters).
+``total_surface``: Array of the total amplitude of each DM actuator (nanometers).
 
-``channels[channel_name]``: The command per virtual channel, identified by channel name.
+``channels[channel_name]``: The command (nm surface) per virtual channel, identified by channel name.

--- a/docs/services/bmc_dm.rst
+++ b/docs/services/bmc_dm.rst
@@ -1,5 +1,8 @@
 Boston Deformable Mirror
 ========================
+This service operates a Boston Micromachines MEMS DM. The following Boston DMs have been tested with catkit2 thus far:
+
+- `BMC DM Kilo-C-1.5 <https://bostonmicromachines.com/products/deformable-mirrors/standard-deformable-mirrors/>`_
 
 Configuration
 -------------
@@ -22,7 +25,7 @@ Configuration
         dm_mask_fname: !path ../dm_mask.fits
 
     startup_maps:
-        flat: !path ../data/flat.fits
+        flat: !path ../flat_data.fits
 
     channels:
         - correction_howfs
@@ -37,9 +40,16 @@ Configuration
 
 Properties
 ----------
+``channels``: List of command channel names (strings).
 
 Commands
 --------
 
 Datastreams
 -----------
+``total_voltage``: Map of the total voltage applied to each actuator of the DM.
+
+``total_surface``: Map of the total amplitude of each DM actuator (meters).
+
+``channel_name``: Name of the DM channel being commanded.
+

--- a/docs/services/bmc_dm.rst
+++ b/docs/services/bmc_dm.rst
@@ -5,24 +5,35 @@ Configuration
 -------------
 .. code-block:: YAML
 
-    boston_dm1:
-        inclination:
-          design: 0
-          calibrated:
-        clocking:
-          design: 0
-          calibrated:
-        actuator_pitch: 150.0e-6
-        num_actuators_across: 48
-        reflective_diameter: 100.0e-3
-        include_actuator_print_through: false
+    boston_dm:
+        service_type: bmc_dm
+        simulated_service_type: bmc_dm_sim
+        interface: bmc_dm
+        requires_safety: true
+
+        serial_number: 0000
+        command_length: 2048
+        num_actuators: 952
+        dac_bit_depth: 14
         max_volts: 200
-        active_actuator_mask: !path "../data/boston/rst_dm_2Dmask.fits"
-        actuator_influence_function: !path "../data/boston/boston_actuator_for_rst48.fits"
-        actuator_print_through: !path "../data/boston/boston_mems_actuator_medres.fits"
-        flat_map_voltage: !path "../data/boston/flat_map_volts_rst48.fits"
-        meter_per_volt_map: !path "../data/boston/gain_map_rst48.fits"
-        zero_padding_factor: 2  # 0 indicates no zero-padding.
+
+        flat_map_fname: !path ../flat_data.fits
+        gain_map_fname: !path ../gain_map.fits
+        dm_mask_fname: !path ../dm_mask.fits
+
+    startup_maps:
+        flat: !path ../data/flat.fits
+
+    channels:
+        - correction_howfs
+        - correction_lowfs
+        - probe
+        - poke
+        - aberration
+        - atmosphere
+        - astrogrid
+        - resume
+        - flat
 
 Properties
 ----------

--- a/docs/services/bmc_dm.rst
+++ b/docs/services/bmc_dm.rst
@@ -1,6 +1,6 @@
 Boston Deformable Mirror
 ========================
-This service operates a Boston Micromachines MEMS DM. The following Boston DMs have been tested with catkit2 thus far:
+This service operates a pair of identical Boston Micromachines MEMS DMs controlled by the same driver. The following Boston DMs have been tested with catkit2 thus far:
 
 - `BMC DM Kilo-C-1.5 <https://bostonmicromachines.com/products/deformable-mirrors/standard-deformable-mirrors/>`_
 

--- a/docs/services/flir_camera.rst
+++ b/docs/services/flir_camera.rst
@@ -8,6 +8,8 @@ For further documentation, see:
 
 - `image format control <http://softwareservices.flir.com/BFS-U3-200S6/latest/Model/public/ImageFormatControl.html>`_
 
+Note that using FLIR cameras requires a manual installation of drivers from `flir.custhelp.com <https://flir.custhelp.com/app/answers/detail/a_id/47/~/flir-cameras---drivers>`_
+
 Configuration
 -------------
 .. code-block:: YAML

--- a/docs/services/flir_camera.rst
+++ b/docs/services/flir_camera.rst
@@ -8,7 +8,7 @@ For further documentation, see:
 
 - `image format control <http://softwareservices.flir.com/BFS-U3-200S6/latest/Model/public/ImageFormatControl.html>`_
 
-Note that using FLIR cameras requires a manual installation of drivers from `flir.custhelp.com <https://flir.custhelp.com/app/answers/detail/a_id/47/~/flir-cameras---drivers>`_
+Note that using FLIR cameras requires a manual installation of drivers from `flir.com. <https://www.flir.com/support-center/iis/machine-vision/knowledge-base/technical-documentation-blackfly-s-usb3/>`_
 
 Configuration
 -------------

--- a/docs/services/flir_camera.rst
+++ b/docs/services/flir_camera.rst
@@ -1,14 +1,75 @@
 FLIR Camera
 ===========
+This service operates an FLIR camera. The following are the different types of FLIR cameras that have been tested and used with catkit2 so far:
+
+- `Teledyne FLIR BFS-U3-63S4M-C <https://wilcoimaging.com/products/teledyne-flir-bfs-u3-63s4m-c?_pos=1&_sid=ff2b850d4&_ss=r>`_
+
+For further documentation, see:
+
+- `image format control <http://softwareservices.flir.com/BFS-U3-200S6/latest/Model/public/ImageFormatControl.html>`_
 
 Configuration
 -------------
+.. code-block:: YAML
+
+    camera1:
+        service_type: flir_camera
+        simulated_service_type: camera_sim
+        requires_safety: false
+
+        serial_number: 000000
+        width: 312
+        height: 312
+        offset_x: 100
+        offset_y: 134
+        adc_bit_depth: 12bit
+        pixel_format: mono12p
+        well_depth_percentage_target: 0.65
+        exposure_time: 1000
+        gain: 0
+        env:
+            KMP_DUPLICATE_LIB_OK: TRUE
 
 Properties
 ----------
+``exposure_time``: Exposure time (in microseconds) of the camera.
+
+``gain``: Gain of the camera.
+
+``width``: The width of the camera frames.
+
+``height``: The height of the camera frames.
+
+``offset_x``: The x offset of the camera frames on the sensor.
+
+``offset_y``: The y offset of the camera frames on the sensor.
+
+``sensor_width``: The width of the sensor.
+
+``sensor_height``: The height of the sensor.
+
+``pixel_format``: Format of the pixel provided by the camera.
+
+``adc_bit_depth``: Fixed bit output of the camera ADC.
+
+``acquisition_frame_rate``: Frame rate of the acquisition (if enabled, see below).
+
+``acquisition_frame_rate_enable``: Whether to allow manual control of the acquisition frame rate.
+
+``device_name``: The name of the camera.
 
 Commands
 --------
+``start_acquisition()``: This starts the acquisition of images from the camera.
+
+``end_acquisition()``: This ends the acquisition of images from the camera.
+
 
 Datastreams
 -----------
+``temperature``: The temperature (in Celsius) as measured by the camera.
+
+``images``: The images acquired by the camera.
+
+``is_acquiring``: Whether the camera is currently acquiring images.
+

--- a/docs/services/nkt_superk.rst
+++ b/docs/services/nkt_superk.rst
@@ -4,7 +4,7 @@ The NKT Super K service contains software for controlling both the `NKT SuperK E
 and the `NKT SuperK VARIA Variable Bandpass Filter <https://contentnktphotonics.s3.eu-central-1.amazonaws.com/SuperK-VARIA/SuperK%20VARIA%20Product%20Guide-%2020231016%20R1.3.pdf>`_.
 This is done because a single open port to the device is needed that cannot be shared between multiple services.
 
-Associated drivers for both the EVO and VARIA (found in the lined manuals) also need to be installed.
+Associated drivers for both the EVO and VARIA (found in the linked manuals) also need to be installed.
 
 Configuration
 -------------

--- a/docs/services/nkt_superk.rst
+++ b/docs/services/nkt_superk.rst
@@ -1,8 +1,30 @@
 NKT Super K Compact Tunable Laser
 =================================
+The NKT Super K service contains both the `NKT SuperK EVO Supercontinuum White Light Laser <https://contentnktphotonics.s3.eu-central-1.amazonaws.com/SuperK-EVO/SuperK%20EVO%20and%20EVO%20HP%20Product%20Guide-%2020231010%20R1.4.pdf>`_
+and the `NKT SuperK VARIA Variable Bandpass Filter <https://contentnktphotonics.s3.eu-central-1.amazonaws.com/SuperK-VARIA/SuperK%20VARIA%20Product%20Guide-%2020231016%20R1.3.pdf>`_.
+
+
 
 Configuration
 -------------
+
+.. code-block:: YAML
+
+    nkt_superk:
+        service_type: nkt_superk
+        simulated_service_type: nkt_superk_sim
+        interface: nkt_superk
+        requires_safety: false
+
+        port: COM4
+        emission: 1
+        power_setpoint: 100
+        current_setpoint: 100
+        nd_setpoint: 1.0
+        lwp_setpoint: 633
+        swp_setpoint: 643
+        sleep_time_per_nm: 0.013
+        base_sleep_time: 0.05
 
 Properties
 ----------
@@ -12,3 +34,29 @@ Commands
 
 Datastreams
 -----------
+``base_temperature``: Base temperature output by the NKT EVO (Celsius).
+
+``supply_voltage``: DC supply voltage to the NKT EVO.
+
+``external_control_input``:
+
+``emission``: Output emission
+
+``power_setpoint``: Output emission power level (in percent)
+
+``current_setpoint``:
+
+``monitor_input``:
+
+``nd_setpoint``:
+
+``swp_setpoint``:
+
+``lwp_setpoint``:
+
+``nd_filter_moving``:
+
+``swp_filter_moving``:
+
+``lwp_filter_moving``:
+

--- a/docs/services/nkt_superk.rst
+++ b/docs/services/nkt_superk.rst
@@ -1,9 +1,10 @@
 NKT Super K Compact Tunable Laser
 =================================
-The NKT Super K service contains both the `NKT SuperK EVO Supercontinuum White Light Laser <https://contentnktphotonics.s3.eu-central-1.amazonaws.com/SuperK-EVO/SuperK%20EVO%20and%20EVO%20HP%20Product%20Guide-%2020231010%20R1.4.pdf>`_
+The NKT Super K service contains software for controlling both the `NKT SuperK EVO Supercontinuum White Light Laser <https://contentnktphotonics.s3.eu-central-1.amazonaws.com/SuperK-EVO/SuperK%20EVO%20and%20EVO%20HP%20Product%20Guide-%2020231010%20R1.4.pdf>`_
 and the `NKT SuperK VARIA Variable Bandpass Filter <https://contentnktphotonics.s3.eu-central-1.amazonaws.com/SuperK-VARIA/SuperK%20VARIA%20Product%20Guide-%2020231016%20R1.3.pdf>`_.
+This is done because a single open port to the device is needed that cannot be shared between multiple services.
 
-
+Associated drivers for both the EVO and VARIA (found in the lined manuals) also need to be installed.
 
 Configuration
 -------------
@@ -20,7 +21,7 @@ Configuration
         emission: 1
         power_setpoint: 100
         current_setpoint: 100
-        nd_setpoint: 1.0
+        nd_setpoint: 100
         lwp_setpoint: 633
         swp_setpoint: 643
         sleep_time_per_nm: 0.013
@@ -34,29 +35,29 @@ Commands
 
 Datastreams
 -----------
-``base_temperature``: Base temperature output by the NKT EVO (Celsius).
+``base_temperature``: Base temperature output by the EVO (Celsius).
 
-``supply_voltage``: DC supply voltage to the NKT EVO.
+``supply_voltage``: DC supply voltage to the EVO.
 
-``external_control_input``:
+``external_control_input``: Level of external feedback control for the EVO (Volts, DC).
 
-``emission``: Output emission
+``emission``: Output emission of the EVO (int) - 0 is OFF, 1 is ON.
 
-``power_setpoint``: Output emission power level (in percent)
+``power_setpoint``: Output emission power level of the EVO (in percent).
 
-``current_setpoint``:
+``current_setpoint``: Output current level of the EVO (in percent).
 
-``monitor_input``:
+``monitor_input``: Monitors the input to the VARIA from the EVO.
 
-``nd_setpoint``:
+``nd_setpoint``: Set point for the VARIA ND filter.
 
-``swp_setpoint``:
+``swp_setpoint``: Upper bandwidth limit for the VARIA (in nm).
 
-``lwp_setpoint``:
+``lwp_setpoint``: Lower bandwidth limit for the VARIA (in nm).
 
-``nd_filter_moving``:
+``nd_filter_moving``: Whether the ND filer is moving for the VARIA.
 
-``swp_filter_moving``:
+``swp_filter_moving``: Whether the short wavelength (high-pass) filter is moving for the VARIA.
 
-``lwp_filter_moving``:
+``lwp_filter_moving``: Whether the long wavelength (low-pass) filter is moving for the VARIA.
 

--- a/docs/services/nkt_superk.rst
+++ b/docs/services/nkt_superk.rst
@@ -30,8 +30,12 @@ Configuration
 Properties
 ----------
 
+None.
+
 Commands
 --------
+
+None.
 
 Datastreams
 -----------


### PR DESCRIPTION
This is part of the team effort to fill out the documentation pages in the services module of catkit2 (see issue #190 for more information).

service docs included in this PR:
- [x] bmc_dm  
- [x] nkt_superk
- [x] FLIR camera