### PR TITLE
Raise a timeout error if newport picomotor is stalling

### DIFF
--- a/catkit2/testbed/proxies/newport_picomotor.py
+++ b/catkit2/testbed/proxies/newport_picomotor.py
@@ -58,7 +58,7 @@ class NewportPicomotorProxy(ServiceProxy):
                         raise
                     else:
                         # Datastream read timed out. This is to facilitate wait time checking, so this is normal.
-                        pass
+                        raise TimeoutError('Picomotor motion timed out.')
 
                 # Send a log message to indicate we are still waiting.
                 current_position = stream.get()[0]


### PR DESCRIPTION
One of the newport picomotors keeps stalling and needs to be restarted manually. By implementing this, it enables other code to catch the error and handle it properly instead of stalling the experiments. 

The reason behind the stalling has not been understood yet.  