### PR TITLE
Fix newport picomotor failures

### DIFF
--- a/catkit2/services/newport_picomotor/newport_picomotor.py
+++ b/catkit2/services/newport_picomotor/newport_picomotor.py
@@ -72,7 +72,7 @@ class NewportPicomotor(Service):
         self.log.info(f'Done. Position is now {position_after}.')
 
         if position_after != position:
-            raise RuntimeError('Newport picomotor failed to move to {position}; currently at {position_after}. Try increasing sleep_per_step.')
+            raise RuntimeError(f'Newport picomotor failed to move axis {axis_name} to {position}; currently at {position_after}. Try increasing sleep_per_step.')
 
     def get_current_position(self, axis_name):
         axis = self.axes[axis_name]

--- a/catkit2/testbed/proxies/newport_picomotor.py
+++ b/catkit2/testbed/proxies/newport_picomotor.py
@@ -17,7 +17,7 @@ class NewportPicomotorProxy(ServiceProxy):
         stream = getattr(self, axis_name.lower() + '_current_position')
         current_position = stream.get()[0]
 
-        new_position = current_position + distance
+        new_position = np.int32(current_position + distance)
 
         self.move_absolute(axis_name, new_position, timeout=timeout)
 


### PR DESCRIPTION
Casting to integers twice before submitting to the datastream somehow prevents the failures to happen.  

Tested on HiCAT with 1000 target acquisition experiments back to back without problem (vs. usually fails after ~10 / 15 TA experiments). 

The why has not been understood yet. 

Mainly solves the issue in https://github.com/spacetelescope/hicat-package2/issues/435, but will not close it since we do not understand what is going on exactly. 