### PR TITLE
Benchmarks in C++

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build_docs:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4
@@ -23,6 +23,11 @@ jobs:
       with:
           auto-update-conda: true
           auto-activate-base: false
+    - name: Switch to gcc-10 on linux
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt install gcc-10 g++-10 cpp-10
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
     - name: Install dependencies
       run: |
         cd extern/

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,8 +25,8 @@ jobs:
           miniconda-version: "latest"
           auto-update-conda: true
           auto-activate-base: false
-    - name: Switch to gcc-11 on linux
-      if: matrix.os == 'ubuntu-22.04'
+    - name: Switch to gcc-10 on linux
+      if: runner.os == 'Linux'
       run: |
         sudo apt install gcc-10 g++-10 cpp-10
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,6 +25,12 @@ jobs:
           miniconda-version: "latest"
           auto-update-conda: true
           auto-activate-base: false
+    - name: Switch to gcc-11 on linux
+      if: matrix.os == 'ubuntu-20.04'
+      run: |
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+        sudo apt install g++-11
+        sudo update-alternatives --set g++ /usr/bin/g++-11
     - name: Install dependencies
       run: |
         cd extern/

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,7 +28,8 @@ jobs:
     - name: Switch to gcc-11 on linux
       if: matrix.os == 'ubuntu-22.04'
       run: |
-        sudo update-alternatives --set g++ /usr/bin/g++-11
+        sudo apt install gcc-10 g++-10 cpp-10
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
     - name: Install dependencies
       run: |
         cd extern/

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-latest, macos-latest]
+        os: [ubuntu-22.04, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -26,10 +26,8 @@ jobs:
           auto-update-conda: true
           auto-activate-base: false
     - name: Switch to gcc-11 on linux
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-22.04'
       run: |
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-        sudo apt install g++-11
         sudo update-alternatives --set g++ /usr/bin/g++-11
     - name: Install dependencies
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ project(catkit2)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 
+set(CMAKE_MACOSX_RPATH ON)
+list(APPEND CMAKE_INSTALL_RPATH $ENV{CONDA_PREFIX}/lib)
+
 # Ensure that conda-installed libraries take precedence over
 # system installed libraries.
 list(APPEND CMAKE_PREFIX_PATH "$ENV{CONDA_PREFIX}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,3 +12,4 @@ list(APPEND CMAKE_PREFIX_PATH "$ENV{CONDA_PREFIX}/Library")
 
 add_subdirectory(catkit_core)
 add_subdirectory(catkit_bindings)
+add_subdirectory(benchmarks)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(catkit2)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
+
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+  message(FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt.")
+endif()
+
+# DataStream latency benchmark
+add_executable(datastream_latency datastream_latency.cpp)
+target_include_directories(datastream_latency PUBLIC ../catkit_core)
+target_link_libraries(datastream_latency PUBLIC catkit_core)
+
+# Datastream submit benchmark
+add_executable(datastream_submit datastream_submit.cpp)
+target_include_directories(datastream_submit PUBLIC ../catkit_core)
+target_link_libraries(datastream_submit PUBLIC catkit_core)
+
+# Timestamp benchmark
+add_executable(timestamp timestamp.cpp)
+target_include_directories(timestamp PUBLIC ../catkit_core)
+target_link_libraries(timestamp PUBLIC catkit_core)
+
+# Add install files
+install(TARGETS datastream_latency DESTINATION bin)
+install(TARGETS datastream_submit DESTINATION bin)
+install(TARGETS timestamp DESTINATION bin)

--- a/benchmarks/datastream_latency.cpp
+++ b/benchmarks/datastream_latency.cpp
@@ -1,0 +1,91 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <thread>
+#include <chrono>
+#include <numeric>
+#include <fstream>
+
+#include "DataStream.h"
+#include "Timing.h"
+
+const size_t NUM_ITERATIONS = 1000000;
+
+void submit(std::string stream_id)
+{
+	std::cout << "Running latency benchmark";
+
+	auto stream = DataStream::Open(stream_id);
+
+	for (size_t i = 0; i < NUM_ITERATIONS; ++i)
+	{
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+
+		auto frame = stream->RequestNewFrame();
+		stream->SubmitFrame(frame.m_Id);
+
+		if (i % (NUM_ITERATIONS / 10) == 0)
+		{
+			std::cout << "." << std::flush;
+		}
+	}
+
+	std::cout << std::endl;
+}
+
+void receive(std::string stream_id)
+{
+	auto stream = DataStream::Open(stream_id);
+
+	std::vector<size_t> latencies(NUM_ITERATIONS);
+
+	for (size_t i = 0; i < NUM_ITERATIONS; ++i)
+	{
+		auto frame = stream->GetNextFrame(1000);
+		auto time = GetTimeStamp();
+
+		latencies[i] = time - frame.m_TimeStamp;
+	}
+
+	double sum = std::accumulate(latencies.begin(), latencies.end(), 0.0);
+	double mean = sum / latencies.size();
+
+	double sq_sum = std::inner_product(latencies.begin(), latencies.end(), latencies.begin(), 0.0);
+	double stdev = std::sqrt(sq_sum / latencies.size() - mean * mean);
+
+	std::cout << mean << " +/- " << stdev << " ns" << std::endl;
+
+	// Write results to a file.
+	std::ofstream file;
+	file.open("results.txt");
+
+	for (auto &latency : latencies)
+	{
+		file << latency << std::endl;
+	}
+
+	file.close();
+
+	std::cout << "All latencies were written to results.txt." << std::endl;
+}
+
+int main(int argc, char *argv[])
+{
+	const size_t N = 16;
+	const size_t NUM_FRAMES_IN_BUFFER = 20;
+
+	auto stream_name = std::to_string(GetTimeStamp());
+	auto stream = DataStream::Create(stream_name, "benchmark", DataType::DT_FLOAT64, {N, N}, NUM_FRAMES_IN_BUFFER);
+
+	std::thread receive_thread(receive, stream->GetStreamId());
+
+	// Make sure that the receive thread has started.
+	std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+	std::thread submit_thread(submit, stream->GetStreamId());
+
+	submit_thread.join();
+	receive_thread.join();
+
+	return 0;
+}

--- a/benchmarks/datastream_latency.cpp
+++ b/benchmarks/datastream_latency.cpp
@@ -5,11 +5,23 @@
 #include <chrono>
 #include <numeric>
 #include <fstream>
+#include <atomic>
 
 #include "DataStream.h"
 #include "Timing.h"
 
 const size_t NUM_ITERATIONS = 1000000;
+
+void sleep(std::uint64_t ns)
+{
+	auto start = GetTimeStamp();
+
+	while (GetTimeStamp() - start < ns)
+	{
+	}
+}
+
+std::atomic_bool ready = false;
 
 void submit(std::string stream_id)
 {
@@ -19,7 +31,13 @@ void submit(std::string stream_id)
 
 	for (size_t i = 0; i < NUM_ITERATIONS; ++i)
 	{
-		std::this_thread::sleep_for(std::chrono::microseconds(100));
+		while (!ready)
+		{
+		}
+
+		ready = false;
+
+		sleep(1000);
 
 		auto frame = stream->RequestNewFrame();
 		stream->SubmitFrame(frame.m_Id);
@@ -41,6 +59,8 @@ void receive(std::string stream_id)
 
 	for (size_t i = 0; i < NUM_ITERATIONS; ++i)
 	{
+		ready = true;
+
 		auto frame = stream->GetNextFrame(1000);
 		auto time = GetTimeStamp();
 

--- a/benchmarks/datastream_latency.cpp
+++ b/benchmarks/datastream_latency.cpp
@@ -12,7 +12,7 @@
 
 const size_t NUM_ITERATIONS = 1000000;
 
-void sleep(std::uint64_t ns)
+void fast_sleep(std::uint64_t ns)
 {
 	auto start = GetTimeStamp();
 
@@ -37,7 +37,7 @@ void submit(std::string stream_id)
 
 		ready = false;
 
-		sleep(1000);
+		fast_sleep(1000);
 
 		auto frame = stream->RequestNewFrame();
 		stream->SubmitFrame(frame.m_Id);

--- a/benchmarks/datastream_submit.cpp
+++ b/benchmarks/datastream_submit.cpp
@@ -13,7 +13,7 @@ void benchmark(size_t N, bool with_data)
 	auto stream_name = std::to_string(GetTimeStamp());
 	auto stream = DataStream::Create(stream_name, "benchmark", DataType::DT_FLOAT64, {N, N}, NUM_FRAMES_IN_BUFFER);
 
-	unsigned char *data = new unsigned char[N*N];
+	char *data = new char[N * N * 8];
 
 	auto start = GetTimeStamp();
 

--- a/benchmarks/datastream_submit.cpp
+++ b/benchmarks/datastream_submit.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "DataStream.h"
+#include "Timing.h"
+
+const size_t NUM_ITERATIONS = 10000;
+
+void benchmark(bool with_data)
+
+int main(int argc, char *argv[])
+{
+	std::vector<size_t> Ns = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048};
+
+	for (auto &N : Ns)
+	{
+		const size_t NUM_FRAMES_IN_BUFFER = 20;
+
+		auto stream_name = std::to_string(GetTimeStamp());
+		auto stream = DataStream::Create(stream_name, "benchmark", DataType::DT_FLOAT64, {N, N}, NUM_FRAMES_IN_BUFFER);
+
+		unsigned char *data = new unsigned char[N*N];
+
+		auto start = GetTimeStamp();
+
+		for (size_t j = 0; j < NUM_ITERATIONS; ++j)
+		{
+			stream->SubmitData(data);
+		}
+
+		auto end = GetTimeStamp();
+		auto time_per_iteration = double(end - start) / NUM_ITERATIONS;
+
+		delete[] data;
+
+		std::cout << N << "x" << N << ": " << time_per_iteration << " ns per submit" << std::endl;
+	}
+
+	return 0;
+}

--- a/benchmarks/datastream_submit.cpp
+++ b/benchmarks/datastream_submit.cpp
@@ -6,35 +6,50 @@
 #include "Timing.h"
 
 const size_t NUM_ITERATIONS = 10000;
+const size_t NUM_FRAMES_IN_BUFFER = 20;
 
-void benchmark(bool with_data)
+void benchmark(size_t N, bool with_data)
+{
+	auto stream_name = std::to_string(GetTimeStamp());
+	auto stream = DataStream::Create(stream_name, "benchmark", DataType::DT_FLOAT64, {N, N}, NUM_FRAMES_IN_BUFFER);
+
+	unsigned char *data = new unsigned char[N*N];
+
+	auto start = GetTimeStamp();
+
+	for (size_t j = 0; j < NUM_ITERATIONS; ++j)
+	{
+		if (with_data)
+		{
+			stream->SubmitData(data);
+		}
+		else
+		{
+			auto frame = stream->RequestNewFrame();
+			stream->SubmitFrame(frame.m_Id);
+		}
+	}
+
+	auto end = GetTimeStamp();
+	auto time_per_iteration = double(end - start) / NUM_ITERATIONS;
+
+	delete[] data;
+
+	std::cout << N << "x" << N << ": " << time_per_iteration << " ns per submit" << std::endl;
+}
 
 int main(int argc, char *argv[])
 {
 	std::vector<size_t> Ns = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048};
 
-	for (auto &N : Ns)
+	for (auto &with_data : {true, false})
 	{
-		const size_t NUM_FRAMES_IN_BUFFER = 20;
+		std::cout << (with_data ? "With" : "Without") << " copying data:" << std::endl;
 
-		auto stream_name = std::to_string(GetTimeStamp());
-		auto stream = DataStream::Create(stream_name, "benchmark", DataType::DT_FLOAT64, {N, N}, NUM_FRAMES_IN_BUFFER);
-
-		unsigned char *data = new unsigned char[N*N];
-
-		auto start = GetTimeStamp();
-
-		for (size_t j = 0; j < NUM_ITERATIONS; ++j)
+		for (auto &N : Ns)
 		{
-			stream->SubmitData(data);
+			benchmark(N, with_data);
 		}
-
-		auto end = GetTimeStamp();
-		auto time_per_iteration = double(end - start) / NUM_ITERATIONS;
-
-		delete[] data;
-
-		std::cout << N << "x" << N << ": " << time_per_iteration << " ns per submit" << std::endl;
 	}
 
 	return 0;

--- a/benchmarks/latency_histogram.py
+++ b/benchmarks/latency_histogram.py
@@ -1,0 +1,24 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+latencies = []
+
+with open('results.txt') as f:
+    for line in f.readlines():
+        latencies.append(float(line) / 1000)
+
+print(len(latencies))
+
+plt.hist(latencies, bins=np.arange(0, 100))
+plt.yscale('log')
+
+quantiles = [0.5, 0.99, 0.999, 0.9999]
+for q in quantiles:
+    p = np.quantile(latencies, q)
+    plt.axvline(p, c='k')
+    plt.text(p, 1e6, f'{float(q * 100)}%', horizontalalignment='right', verticalalignment='bottom', rotation=90)
+plt.ylim(5e-1, 2e7)
+
+plt.xlabel('Latency [us]')
+plt.ylabel('Occurance')
+plt.show()

--- a/benchmarks/timestamp.cpp
+++ b/benchmarks/timestamp.cpp
@@ -1,0 +1,21 @@
+#include <iostream>
+
+#include "Timing.h"
+
+const size_t NUM_ITERATIONS = 100000000;
+
+int main(int argc, char *argv[])
+{
+    auto start = GetTimeStamp();
+
+    for (size_t i = 0; i < NUM_ITERATIONS; ++i)
+    {
+        GetTimeStamp();
+    }
+
+    auto end = GetTimeStamp();
+
+    std::cout << double(end - start) / NUM_ITERATIONS << " ns per timestamp" << std::endl;
+
+	return 0;
+}

--- a/catkit_core/CMakeLists.txt
+++ b/catkit_core/CMakeLists.txt
@@ -54,7 +54,7 @@ target_link_libraries(catkit_core PUBLIC libzmq)
 if (WIN32)
   target_link_libraries(catkit_core PUBLIC wsock32 ws2_32 Iphlpapi)
 else()
-  target_link_libraries(catkit_core PUBLIC pthread)
+  target_link_libraries(catkit_core PUBLIC pthread rt)
 endif (WIN32)
 
 # Add includes for cppzmq

--- a/catkit_core/CMakeLists.txt
+++ b/catkit_core/CMakeLists.txt
@@ -54,7 +54,10 @@ target_link_libraries(catkit_core PUBLIC libzmq)
 if (WIN32)
   target_link_libraries(catkit_core PUBLIC wsock32 ws2_32 Iphlpapi)
 else()
-  target_link_libraries(catkit_core PUBLIC pthread rt)
+  target_link_libraries(catkit_core PUBLIC pthread)
+  if (NOT APPLE)
+    target_link_libraries(catkit_core PUBLIC rt)
+  endif (NOT APPLE)
 endif (WIN32)
 
 # Add includes for cppzmq

--- a/catkit_core/DataStream.cpp
+++ b/catkit_core/DataStream.cpp
@@ -218,8 +218,7 @@ void DataStream::SubmitData(const void *data)
 
 	DataFrame frame = RequestNewFrame();
 
-	char *source = (char *) data;
-	std::copy(source, source + frame.GetSizeInBytes(), frame.m_Data);
+	std::memcpy(frame.m_Data, data, frame.GetSizeInBytes());
 
 	SubmitFrame(frame.m_Id);
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@
 
 name: catkit2
 dependencies:
-  - python=3.7.17
+  - python=3.7.16
   - numpy
   - scipy
   - matplotlib

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@
 
 name: catkit2
 dependencies:
-  - python=3.7.6
+  - python=3.7.17
   - numpy
   - scipy
   - matplotlib


### PR DESCRIPTION
Description
===

Add benchmarks for datastream latency (between submitting and receiving), datastream submitting itself (including copy) and timestamping. All benchmarks written in C++ to benchmark the internal speed and not the wrapper to Python.

- [x] Testing on MacOS.
- [x] Testing on Windows.

Fixes https://github.com/spacetelescope/catkit2/issues/241

MacOS benchmarks
===
Performed on Macbook Pro 16" M2 Max (12 cores, 64GB memory)

Submitting
---
```
With copying data:
1x1: 88.4 ns per submit
2x2: 88.5 ns per submit
4x4: 87.5 ns per submit
8x8: 84.5 ns per submit
16x16: 135.3 ns per submit
32x32: 303.7 ns per submit
64x64: 685.5 ns per submit
128x128: 2257 ns per submit
256x256: 8506.1 ns per submit
512x512: 34081.5 ns per submit
1024x1024: 165554 ns per submit
2048x2048: 611174 ns per submit

Without copying data:
1x1: 44.9 ns per submit
2x2: 47 ns per submit
4x4: 48.9 ns per submit
8x8: 48.5 ns per submit
16x16: 48.8 ns per submit
32x32: 52.4 ns per submit
64x64: 50.6 ns per submit
128x128: 51.7 ns per submit
256x256: 49.5 ns per submit
512x512: 50.2 ns per submit
1024x1024: 54.2 ns per submit
2048x2048: 51 ns per submit
```

Latency
---
![image](https://github.com/user-attachments/assets/3b485609-2e27-4779-96bf-53bea8a19365)

Timestamping
---
```
15.1287 ns per timestamp
```

Windows benchmarks
===
Performed on hicat-deux: 

Submitting
---
```
With copying data:
1x1: 93.87 ns per submit
2x2: 95.07 ns per submit
4x4: 95.32 ns per submit
8x8: 104.26 ns per submit
16x16: 122.25 ns per submit
32x32: 214.08 ns per submit
64x64: 1566.98 ns per submit
128x128: 5815.06 ns per submit
256x256: 25002 ns per submit
512x512: 310941 ns per submit
1024x1024: 1.18724e+06 ns per submit
2048x2048: 6.40234e+06 ns per submit
Without copying data:
1x1: 127.61 ns per submit
2x2: 90.66 ns per submit
4x4: 91.51 ns per submit
8x8: 92.12 ns per submit
16x16: 90.98 ns per submit
32x32: 91.34 ns per submit
64x64: 91.23 ns per submit
128x128: 90.88 ns per submit
256x256: 91.25 ns per submit
512x512: 90.91 ns per submit
1024x1024: 122.83 ns per submit
2048x2048: 91.16 ns per submit
```

Latency
---
![Screenshot 2024-08-22 175353](https://github.com/user-attachments/assets/6db9ff02-2480-495f-a052-34ecd67dedf8)

Timestamping
---
```
23.8282 ns per timestamp
```