### PR TITLE
Bugfix/mcls1 sim

### DIFF
--- a/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
+++ b/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
@@ -104,9 +104,6 @@ class ThorlabsMcls1Sim(Service):
     def get_temperature(self):
         return self.config['target_temperature']
 
-    def get_temperature(self):
-        return self.config['target_temperature']
-
 
 if __name__ == '__main__':
     service = ThorlabsMcls1Sim()

--- a/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
+++ b/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
@@ -74,12 +74,6 @@ class ThorlabsMcls1Sim(Service):
         for thread in self.threads.values():
             thread.join()
 
-    def update_status_func(self, getter, stream):
-        def func():
-            result = getter()
-            stream.submit_data(np.array([result]).astype(stream.dtype))
-        return func
-
     def update_status(self):
         while not self.should_shut_down:
             for getter in self.getters:

--- a/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
+++ b/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
@@ -40,10 +40,10 @@ class ThorlabsMcls1Sim(Service):
             'target_temperature': self.set_target_temperature,
         }
 
-        self.status_funcs = {
-            'temperature': (self.temperature, self.get_temperature),
-            'power': (self.power, self.get_power)
-        }
+        self.getters = [
+            self.get_temperature,
+            self.get_power
+        ]
 
         for key, setter in self.setters.items():
             func = make_monitor_func(getattr(self, key), setter)
@@ -64,12 +64,7 @@ class ThorlabsMcls1Sim(Service):
 
     def main(self):
         while not self.should_shut_down:
-            try:
-                task, args = self.communication_queue.get(timeout=1)
-                task(*args)
-                self.communication_queue.task_done()
-            except queue.Empty:
-                pass
+            self.sleep(1)
 
     def close(self):
         # Turn off the source
@@ -111,10 +106,7 @@ class ThorlabsMcls1Sim(Service):
         pass
 
     def get_power(self):
-        try:
-            return self.testbed.simulator.light_source_data[self.id + '_power']
-        except KeyError:
-            return 0
+        return self.testbed.simulator.light_source_data[self.id + '_power']
 
     def get_temperature(self):
         return self.config['target_temperature']

--- a/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
+++ b/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
@@ -117,7 +117,11 @@ class ThorlabsMcls1Sim(Service):
         pass
 
     def get_power(self):
-        return self.testbed.simulator.light_source_data[self.id + '_power']
+        try:
+            return self.testbed.simulator.light_source_data[self.id + '_power']
+        except KeyError:
+            return 0
+
     def get_temperature(self):
         return self.config['target_temperature']
 

--- a/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
+++ b/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
@@ -40,10 +40,10 @@ class ThorlabsMcls1Sim(Service):
             'target_temperature': self.set_target_temperature,
         }
 
-        self.getters = [
-            self.get_temperature,
-            self.get_power
-        ]
+        self.status_funcs = {
+            'temperature': (self.temperature, self.get_temperature),
+            'power': (self.power, self.get_power)
+        }
 
         for key, setter in self.setters.items():
             func = make_monitor_func(getattr(self, key), setter)
@@ -107,6 +107,8 @@ class ThorlabsMcls1Sim(Service):
 
     def get_power(self):
         return self.testbed.simulator.light_source_data[self.id + '_power']
+    def get_temperature(self):
+        return self.config['target_temperature']
 
     def get_temperature(self):
         return self.config['target_temperature']

--- a/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
+++ b/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
@@ -1,9 +1,21 @@
 import time
-import queue
 import numpy as np
 import threading
 
 from catkit2.testbed.service import Service
+
+
+def make_monitor_func(stream, setter):
+    def func(self):
+        while not self.should_shut_down:
+            try:
+                frame = stream.get_next_frame(1)
+            except Exception:
+                continue
+
+            setter(frame.data[0])
+
+    return func
 
 
 class ThorlabsMcls1Sim(Service):
@@ -11,7 +23,6 @@ class ThorlabsMcls1Sim(Service):
     def __init__(self):
         super().__init__('thorlabs_mcls1_sim')
         self.threads = {}
-        self.communication_queue = queue.Queue()
 
     def open(self):
         # Make datastreams
@@ -29,20 +40,14 @@ class ThorlabsMcls1Sim(Service):
             'target_temperature': self.set_target_temperature,
         }
 
-        self.status_funcs = {
-            'temperature': (self.temperature, self.get_temperature),
-            'power': (self.power, self.get_power)
-        }
+        self.getters = [
+            self.get_temperature,
+            self.get_power
+        ]
 
-        funcs = {
-            'emission': self.monitor_func(self.emission, self.setters['emission']),
-            'current_setpoint': self.monitor_func(self.current_setpoint, self.setters['current_setpoint']),
-            'target_temperature': self.monitor_func(self.target_temperature, self.setters['target_temperature']),
-        }
-
-        # Start all threads.
-        for key, func in funcs.items():
-            thread = threading.Thread(target=func)
+        for key, setter in self.setters.items():
+            func = make_monitor_func(getattr(self, key), setter)
+            thread = threading.Thread(target=func, args=(self,))
             thread.start()
 
             self.threads[key] = thread
@@ -59,31 +64,15 @@ class ThorlabsMcls1Sim(Service):
 
     def main(self):
         while not self.should_shut_down:
-            try:
-                task, args = self.communication_queue.get(timeout=1)
-                task(*args)
-                self.communication_queue.task_done()
-            except queue.Empty:
-                pass
+            self.sleep(1)
 
     def close(self):
         # Turn off the source
-        self.setters['emission'](self, 0)
+        self.set_emission(0)
 
         # Join all threads.
         for thread in self.threads.values():
             thread.join()
-
-    def monitor_func(self, stream, setter):
-        def func():
-            while not self.should_shut_down:
-                try:
-                    frame = stream.get_next_frame(1)
-                except Exception:
-                    continue
-                self.communication_queue.put((setter, [frame.data[0]]))
-
-        return func
 
     def update_status_func(self, getter, stream):
         def func():
@@ -93,8 +82,8 @@ class ThorlabsMcls1Sim(Service):
 
     def update_status(self):
         while not self.should_shut_down:
-            for stream, getter in self.status_funcs.values():
-                self.communication_queue.put((self.update_status_func(getter, stream), []))
+            for getter in self.getters:
+                getter()
 
             time.sleep(1)
 
@@ -117,10 +106,7 @@ class ThorlabsMcls1Sim(Service):
         pass
 
     def get_power(self):
-        try:
-            return self.testbed.simulator.light_source_data[self.id + '_power']
-        except KeyError:
-            return 0
+        return self.testbed.simulator.light_source_data[self.id + '_power']
 
     def get_temperature(self):
         return self.config['target_temperature']

--- a/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
+++ b/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
@@ -9,7 +9,7 @@ from catkit2.testbed.service import Service
 class ThorlabsMcls1Sim(Service):
 
     def __init__(self):
-        super().__init__('thorlabs_mcls1')
+        super().__init__('thorlabs_mcls1_sim')
         self.threads = {}
         self.communication_queue = queue.Queue()
 

--- a/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
+++ b/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
@@ -64,7 +64,12 @@ class ThorlabsMcls1Sim(Service):
 
     def main(self):
         while not self.should_shut_down:
-            self.sleep(1)
+            try:
+                task, args = self.communication_queue.get(timeout=1)
+                task(*args)
+                self.communication_queue.task_done()
+            except queue.Empty:
+                pass
 
     def close(self):
         # Turn off the source

--- a/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
+++ b/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
@@ -1,4 +1,3 @@
-import time
 import numpy as np
 import threading
 
@@ -79,7 +78,7 @@ class ThorlabsMcls1Sim(Service):
             for getter in self.getters:
                 getter()
 
-            time.sleep(1)
+            self.sleep(1)
 
     def set_emission(self, emission):
         self.testbed.simulator.set_source_power(

--- a/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
+++ b/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
@@ -30,7 +30,7 @@ class ThorlabsMcls1Sim(Service):
         }
 
         self.status_funcs = {
-            'temperature': (self.temperature, lambda: self.config['temperature']),
+            'temperature': (self.temperature, self.get_temperature),
             'power': (self.power, self.get_power)
         }
 
@@ -118,6 +118,8 @@ class ThorlabsMcls1Sim(Service):
 
     def get_power(self):
         return self.testbed.simulator.light_source_data[self.id + '_power']
+    def get_temperature(self):
+        return self.config['target_temperature']
 
 
 if __name__ == '__main__':

--- a/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
+++ b/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
@@ -61,7 +61,7 @@ class ThorlabsMcls1Sim(Service):
         while not self.should_shut_down:
             try:
                 task, args = self.communication_queue.get(timeout=1)
-                task(self, *args)
+                task(*args)
                 self.communication_queue.task_done()
             except queue.Empty:
                 pass
@@ -86,8 +86,8 @@ class ThorlabsMcls1Sim(Service):
         return func
 
     def update_status_func(self, getter, stream):
-        def func(self):
-            result = getter(self)
+        def func():
+            result = getter()
             stream.submit_data(np.array([result]).astype(stream.dtype))
         return func
 

--- a/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
+++ b/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
@@ -111,7 +111,11 @@ class ThorlabsMcls1Sim(Service):
         pass
 
     def get_power(self):
-        return self.testbed.simulator.light_source_data[self.id + '_power']
+        try:
+            return self.testbed.simulator.light_source_data[self.id + '_power']
+        except KeyError:
+            return 0
+
     def get_temperature(self):
         return self.config['target_temperature']
 

--- a/catkit2/simulator/simulator.py
+++ b/catkit2/simulator/simulator.py
@@ -85,6 +85,8 @@ class Simulator(Service):
         self.make_command('switch_power', self.switch_power)
         self.make_command('set_source_power', self.set_source_power)
 
+        self.make_property('light_source_data', lambda: self.light_source_data)
+
         self.integrating_cameras = {}
         self.camera_integrated_power = {}
         self.camera_callbacks = {}


### PR DESCRIPTION
Fixes #238. 

Restores functionality to the `ThorlabsMcls1Sim` service. This includes:

- Fixing mislabeled service type.
- Adding `light_source_data` property to the `Simulator` service.
- Adjusting some of the getters and setters in the `ThorlabsMcls1Sim` service itself. 

**Todo:**

- [x] Test on simulator
- [x] Make sure is consistent with refactoring happening in #243 