### PR TITLE
Feature/steiger service docs round2

### DIFF
--- a/docs/services/camera_sim.rst
+++ b/docs/services/camera_sim.rst
@@ -3,22 +3,24 @@ Camera Simulator
 This service operates a simulated camera. This service is meant to mimic, but does not actually
 control, a hardware camera.
 
-When applicable, all services have a corresponding simulated service to be able to test control
-software before commanding actual hardware devices.
+This service can be used to simulate any hardware camera service since they are all written consistently.
 
 Configuration
 -------------
 .. code-block:: YAML
 
-    camera:
-      service_type: zwo_camera
+    camera1:
+      service_type: my_camera
       simulated_service_type: camera_sim
-      interface: hicat_camera
+      interface: camera
       requires_safety: false
 
+      # Keys used only by hardware service.
       device_name: ZWO ASI178MM
       device_id: 4
       well_depth_percentage_target: 0.65
+
+      # Keys used by simulated and hardware service.
       exposure_time: 1000
       width: 1680
       height: 1680

--- a/docs/services/camera_sim.rst
+++ b/docs/services/camera_sim.rst
@@ -1,14 +1,59 @@
 Camera Simulator
 ================
+This service operates a simulated camera. This service is meant to mimic, but does not actually
+control, a hardware camera.
+
+When applicable, all services have a corresponding simulated service to be able to test control
+software before commanding actual hardware devices.
 
 Configuration
 -------------
+.. code-block:: YAML
+
+    camera:
+      service_type: zwo_camera
+      simulated_service_type: camera_sim
+      interface: hicat_camera
+      requires_safety: false
+
+      device_name: ZWO ASI178MM
+      device_id: 4
+      well_depth_percentage_target: 0.65
+      exposure_time: 1000
+      width: 1680
+      height: 1680
+      offset_x: 336
+      offset_y: 204
+      gain: 0
 
 Properties
 ----------
+``exposure_time``: Simulated exposure time (in microseconds) of the camera.
+
+``gain``: Simulated gain of the camera.
+
+``width``: The width of the camera frames.
+
+``height``: The height of the camera frames.
+
+``offset_x``: The x offset of the camera frames on the sensor.
+
+``offset_y``: The y offset of the camera frames on the sensor.
+
+``sensor_width``: The width of the simulated sensor.
+
+``sensor_height``: The height of the simulated sensor.
 
 Commands
 --------
+``start_acquisition()``: This starts the acquisition of images from the camera.
+
+``end_acquisition()``: This ends the acquisition of images from the camera.
 
 Datastreams
 -----------
+``temperature``: The simulated temperature (in Celsius) as measured by the camera.
+
+``images``: The images acquired by the camera.
+
+``is_acquiring``: Whether the camera is currently acquiring images.

--- a/docs/services/thorlabs_fw102c.rst
+++ b/docs/services/thorlabs_fw102c.rst
@@ -1,14 +1,35 @@
 Thorlabs Filter Wheel
 =====================
+This service operates a `ThorLabs FW 102C <https://www.thorlabs.com/thorproduct.cfm?partnumber=FW102C#ad-image-0>`_
+filter wheel.
 
 Configuration
 -------------
+.. code-block:: YAML
+
+    filter_wheel:
+        service_type: thorlabs_fw102c
+        simulated_service_type: thorlabs_fw102c_sim
+        requires_safety: false
+
+        visa_id: ASRL6::INSTR
+
+        filters:
+          clear: 1
+          2.8_percent: 2
+          12_percent: 3
+          9_percent: 4
 
 Properties
 ----------
+None.
 
 Commands
 --------
+None.
 
 Datastreams
 -----------
+``position``: The requested position of the filter wheel.
+
+``current_position``: The current position of the filter wheel.

--- a/docs/services/thorlabs_fw102c.rst
+++ b/docs/services/thorlabs_fw102c.rst
@@ -17,7 +17,7 @@ Configuration
 
         visa_id: ASRL6::INSTR
 
-        filters:
+        filters: # named positions resolved by the proxy.
           clear: 1
           2.8_percent: 2
           12_percent: 3

--- a/docs/services/thorlabs_fw102c.rst
+++ b/docs/services/thorlabs_fw102c.rst
@@ -1,7 +1,10 @@
 Thorlabs Filter Wheel
 =====================
-This service operates a `ThorLabs FW 102C <https://www.thorlabs.com/thorproduct.cfm?partnumber=FW102C#ad-image-0>`_
-filter wheel.
+This service operates a Thorlabs filter wheel.
+
+Successfully tested with the following devices:
+
+- `ThorLabs FW 102C <https://www.thorlabs.com/thorproduct.cfm?partnumber=FW102C#ad-image-0>`_
 
 Configuration
 -------------
@@ -30,6 +33,6 @@ None.
 
 Datastreams
 -----------
-``position``: The requested position of the filter wheel.
+``position``: The commanded position of the filter wheel. This can have value 1, 2, 3, 4, 5, 6 indicating those respective positions.
 
-``current_position``: The current position of the filter wheel.
+``current_position``: The current position of the filter wheel. This can have value 1, 2, 3, 4, 5, 6 indicating those respective positions.

--- a/docs/services/thorlabs_fw102c.rst
+++ b/docs/services/thorlabs_fw102c.rst
@@ -33,6 +33,6 @@ None.
 
 Datastreams
 -----------
-``position``: The commanded position of the filter wheel. This can have value 1, 2, 3, 4, 5, 6 indicating those respective positions.
+``position``: The commanded position of the filter wheel. This can have the values specified by the service configuration.
 
-``current_position``: The current position of the filter wheel. This can have value 1, 2, 3, 4, 5, 6 indicating those respective positions.
+``current_position``: The current position of the filter wheel. This can have the values specified by the service configuration.

--- a/docs/services/thorlabs_mff101.rst
+++ b/docs/services/thorlabs_mff101.rst
@@ -31,4 +31,5 @@ Commands
 Datastreams
 -----------
 ``current_position``: the current position of the flip mount. This can be set to either 1 or 2, indication position 1 or 2. Other values will be silently ignored.
+
 ``commanded_position``: the commanded position of the flip mount. This can be set to either 1 or 2, indication position 1 or 2. Other values will be silently ignored.

--- a/docs/services/thorlabs_mff101.rst
+++ b/docs/services/thorlabs_mff101.rst
@@ -1,7 +1,8 @@
 Thorlabs Motorized Flip Mount
 =============================
 
-This service operates a Thorlabs MFF101 motorized flip mount.
+This service operates a `Thorlabs MFF101 <https://www.thorlabs.com/thorproduct.cfm?partnumber=MFF101>`_
+motorized flip mount.
 
 Configuration
 -------------
@@ -29,4 +30,5 @@ Commands
 
 Datastreams
 -----------
-``position``: the current (commanded) position of the flip mount. This can be set to either 1 or 2, indication position 1 or 2. Other values will be silently ignored.
+``current_position``: the current position of the flip mount. This can be set to either 1 or 2, indication position 1 or 2. Other values will be silently ignored.
+``commanded_position``: the commanded position of the flip mount. This can be set to either 1 or 2, indication position 1 or 2. Other values will be silently ignored.

--- a/docs/services/thorlabs_mff101.rst
+++ b/docs/services/thorlabs_mff101.rst
@@ -30,6 +30,6 @@ Commands
 
 Datastreams
 -----------
-``current_position``: the current position of the flip mount. This can be set to either 1 or 2, indicating position 1 or 2. Other values will be silently ignored.
+``current_position``: The current position of the flip mount. This can be set to either 1 or 2, indicating position 1 or 2. Other values will be silently ignored.
 
-``commanded_position``: the commanded position of the flip mount. This can be set to either 1 or 2, indicating position 1 or 2. Other values will be silently ignored.
+``commanded_position``: The commanded position of the flip mount. This can be set to either 1 or 2, indicating position 1 or 2. Other values will be silently ignored.

--- a/docs/services/thorlabs_mff101.rst
+++ b/docs/services/thorlabs_mff101.rst
@@ -30,6 +30,6 @@ Commands
 
 Datastreams
 -----------
-``current_position``: the current position of the flip mount. This can be set to either 1 or 2, indication position 1 or 2. Other values will be silently ignored.
+``current_position``: the current position of the flip mount. This can be set to either 1 or 2, indicating position 1 or 2. Other values will be silently ignored.
 
-``commanded_position``: the commanded position of the flip mount. This can be set to either 1 or 2, indication position 1 or 2. Other values will be silently ignored.
+``commanded_position``: the commanded position of the flip mount. This can be set to either 1 or 2, indicating position 1 or 2. Other values will be silently ignored.

--- a/docs/services/thorlabs_tsp01.rst
+++ b/docs/services/thorlabs_tsp01.rst
@@ -1,7 +1,8 @@
 Thorlabs Temperature Sensor
 ===========================
 
-This service retrieves data from a Thorlabs TSP01B temperature and humidity sensor.
+This service retrieves data from a `Thorlabs TSP01 <https://www.thorlabs.com/thorproduct.cfm?partnumber=TSP01>`_
+temperature and humidity sensor.
 
 Configuration
 -------------

--- a/docs/services/thorlabs_tsp01.rst
+++ b/docs/services/thorlabs_tsp01.rst
@@ -1,8 +1,11 @@
 Thorlabs Temperature Sensor
 ===========================
 
-This service retrieves data from a `Thorlabs TSP01 <https://www.thorlabs.com/thorproduct.cfm?partnumber=TSP01>`_
-temperature and humidity sensor.
+This service retrieves data from a Thorlabs temperature and humidity sensor.
+
+Successfully tested with the following devices:
+
+- `Thorlabs TSP01 <https://www.thorlabs.com/thorproduct.cfm?partnumber=TSP01>`_
 
 Configuration
 -------------

--- a/docs/services/thorlabs_tsp01.rst
+++ b/docs/services/thorlabs_tsp01.rst
@@ -1,11 +1,8 @@
 Thorlabs Temperature Sensor
 ===========================
 
-This service retrieves data from a Thorlabs temperature and humidity sensor.
-
-Successfully tested with the following devices:
-
-- `Thorlabs TSP01 <https://www.thorlabs.com/thorproduct.cfm?partnumber=TSP01>`_
+This service retrieves data from a `Thorlabs TSP01 <https://www.thorlabs.com/thorproduct.cfm?partnumber=TSP01>`_
+temperature and humidity sensor.
 
 Configuration
 -------------


### PR DESCRIPTION
Another round of service docs for catkit2 (see issue https://github.com/spacetelescope/catkit2/issues/190 for more information).

Services included:

- Thorlabs temperarure Sensor
- Thorlabs filter wheel
- Thorlabs flip mount 
- Simulated Camera