### PR TITLE
Remove VimbaPython dependency from environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -41,4 +41,3 @@ dependencies:
   - pip:
     - dcps
     - zwoasi>=0.0.21
-    - git+https://github.com/alliedvision/VimbaPython.git@v1.2.1  # See issue #229


### PR DESCRIPTION
Removing the VimbaPython dependency from the environment.yml file since we moved on to https://github.com/alliedvision/VmbPy for the AV cameras anyway. Also, the VimbaPython repo has now been [archived](https://github.com/alliedvision/VimbaPython), and we're getting installation errors.

Note how this does not resolve the issue #229 since I am not adding the VmbPy installation. I haven't had time to test how to install it from their repo (we had [issues with this before](https://github.com/spacetelescope/catkit2/pull/226#issuecomment-2231106502)), and in the meantime I asked whether they might distribute their package rather than having everybody download it manually (https://github.com/alliedvision/VmbPy/issues/39).