### PR TITLE
Fix typo in id property access of Hamamatsu camera

### DIFF
--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -114,7 +114,7 @@ class HamamatsuCamera(Service):
             hot_pixel_correction = 3.0
         else:
             raise ValueError(f'Invalid hot pixel correction: {self.hot_pixel_correction}, must be one of ["standard", "minimum", "aggressive"]')
-        self.cam.prop_setvalue(self.cam.DCAM_IDPROP.HOTPIXELCORRECT_LEVEL, hot_pixel_correction)
+        self.cam.prop_setvalue(dcam.DCAM_IDPROP.HOTPIXELCORRECT_LEVEL, hot_pixel_correction)
 
         self.camera_mode = self.config.get('camera_mode', "standard")
         if self.camera_mode == "ultraquiet":


### PR DESCRIPTION
Fixed a typo in hamamatsu service. 
Found while running benchmark_camera experiment on hardware