### PR TITLE
Adding instructions for Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,23 @@ cd catkit2
 cd extern
 ./download.sh
 cd ..
+```
+For installation on Apple Silicon with python=3.7, you need to follow these steps:
+```
+conda create --name catkit2 
+conda activate catkit2 
+conda config --env --set subdir osx-64 
+conda env update --file environment.yml
+```
+
+For all other platforms, you can use the following command:
+```
 conda env create --file environment.yml
 conda activate catkit2
+```
+
+Finally install the package using: 
+```
 python setup.py develop
 cd ..
 ```


### PR DESCRIPTION
I recently re-installed from scratch on new Mac et realized instructions need to be updated. 
This will go away once we can upgrade python version on hicat project side, we are limited by vendors SDK and stuck at 3.7 at the moment. 