### PR TITLE
Add trace intervals to new DM services from #156

### DIFF
--- a/catkit2/base_services/bmc_deformable_mirror.py
+++ b/catkit2/base_services/bmc_deformable_mirror.py
@@ -54,9 +54,13 @@ class BmcDeformableMirror(DeformableMirrorService):
             # Send voltages to the device.
             self.send_to_device()
 
+            with trace_interval('compute voltage'):
+                discretized_surface = self.discretized_surface
+                discretized_voltages = self.discretized_voltages
+
             # Submit discretized surface and voltages to data streams.
-            self.total_surface.submit_data(self.discretized_surface)
-            self.total_voltage.submit_data(self.discretized_voltages)
+            self.total_surface.submit_data(discretized_surface)
+            self.total_voltage.submit_data(discretized_voltages)
 
     def send_to_device(self):
         '''Send the surface to the simulated/real hardware.

--- a/catkit2/base_services/bmc_deformable_mirror.py
+++ b/catkit2/base_services/bmc_deformable_mirror.py
@@ -1,4 +1,5 @@
 from catkit2.base_services.deformable_mirror import DeformableMirrorService
+from catkit2.testbed.tracing import trace_interval
 
 import numpy as np
 from astropy.io import fits
@@ -47,14 +48,15 @@ class BmcDeformableMirror(DeformableMirrorService):
         surface : ndarray
             The requested surface of the DM(s).
         '''
-        self.surface = surface
+        with trace_interval('send surface'):
+            self.surface = surface
 
-        # Send voltages to the device.
-        self.send_to_device()
+            # Send voltages to the device.
+            self.send_to_device()
 
-        # Submit discretized surface and voltages to data streams.
-        self.total_surface.submit_data(self.discretized_surface)
-        self.total_voltage.submit_data(self.discretized_voltages)
+            # Submit discretized surface and voltages to data streams.
+            self.total_surface.submit_data(self.discretized_surface)
+            self.total_voltage.submit_data(self.discretized_voltages)
 
     def send_to_device(self):
         '''Send the surface to the simulated/real hardware.

--- a/catkit2/base_services/deformable_mirror.py
+++ b/catkit2/base_services/deformable_mirror.py
@@ -1,4 +1,5 @@
 from ..testbed.service import Service
+from catkit2.testbed.tracing import trace_interval
 
 import threading
 import numpy as np
@@ -116,13 +117,15 @@ class DeformableMirrorService(Service):
 
         This co-adds all the DM commands from each channel and applies it to the DM.
         '''
-        # Add up all channels to get the total surface.
-        total_surface = 0
-        for stream in self.channels.values():
-            total_surface += stream.get_latest_frame().data
+        with trace_interval('update dm surface'):
+            with trace_interval('compute total surface'):
+                # Add up all channels to get the total surface.
+                total_surface = 0
+                for stream in self.channels.values():
+                    total_surface += stream.get_latest_frame().data
 
-        # Apply the command on the DM.
-        self.send_surface(total_surface)
+            # Apply the command on the DM.
+            self.send_surface(total_surface)
 
     def send_surface(self, surface):
         '''Send a surface map to the DM(s).

--- a/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
+++ b/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
@@ -1,4 +1,5 @@
 from catkit2.base_services.bmc_deformable_mirror import BmcDeformableMirror
+from catkit2.testbed.tracing import trace_interval
 
 import threading
 import sys
@@ -51,12 +52,13 @@ class BmcDeformableMirrorHardware(BmcDeformableMirror):
         # Convert to hardware command format
         device_command = self.dm_command_to_device_command(self.voltages)
 
-        with self.lock:
-            # Send the voltages to the DM.
-            status = self.device.send_data(device_command)
+        with trace_interval('send data'):
+            with self.lock:
+                # Send the voltages to the DM.
+                status = self.device.send_data(device_command)
 
-            if status != bmc.NO_ERR:
-                raise RuntimeError(f'Failed to send data: {self.device.error_string(status)}.')
+                if status != bmc.NO_ERR:
+                    raise RuntimeError(f'Failed to send data: {self.device.error_string(status)}.')
 
     def dm_command_to_device_command(self, dm_command):
         device_command = np.zeros(self.device_command_length)

--- a/catkit2/services/bmc_deformable_mirror_sim/bmc_deformable_mirror_sim.py
+++ b/catkit2/services/bmc_deformable_mirror_sim/bmc_deformable_mirror_sim.py
@@ -1,4 +1,5 @@
 from catkit2.base_services.bmc_deformable_mirror import BmcDeformableMirror
+from catkit2.testbed.tracing import trace_interval
 import threading
 
 
@@ -9,8 +10,9 @@ class BmcDeformableMirrorSim(BmcDeformableMirror):
         self.lock = threading.Lock()
 
     def send_to_device(self):
-        with self.lock:
-            self.testbed.simulator.actuate_dm(dm_name=self.id, new_actuators=self.discretized_surface)
+        with trace_interval('send data'):
+            with self.lock:
+                self.testbed.simulator.actuate_dm(dm_name=self.id, new_actuators=self.discretized_surface)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #262.

Since we broke up the way voltages and DM surface is computed in the new services, I was unsure where to add the trace interval previously labelled as "compute voltages":
https://github.com/spacetelescope/catkit2/blob/67833ed37cd2fc02e26b03b109df344895b5aa04/catkit2/services/bmc_dm/bmc_dm.py#L100

I have put the others in their respective new place:
- "send surface"
- "update dm surface"
- "compute total surface"
- "send data"

Edit: The "compute voltages" trace was added as the PR progressed.