### PR TITLE
Enable high-resolution dither mode on BMC DMs

### DIFF
--- a/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
+++ b/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
@@ -21,6 +21,7 @@ class BmcDeformableMirrorHardware(BmcDeformableMirror):
         super().__init__('bmc_deformable_mirror_hardware')
 
         self.device_command_index = self.config.get('device_command_index', 0)
+        self.enable_high_resolution = self.config.get('enable_high_resolution', False)
 
         if not isinstance(self.device_command_index, list):
             self.device_command_index = [self.device_command_index]
@@ -29,6 +30,7 @@ class BmcDeformableMirrorHardware(BmcDeformableMirror):
 
     def open(self):
         self.device = bmc.BmcDm()
+        self.device.enable_high_res(enable=self.enable_high_resolution)
         status = self.device.open_dm(self.serial_number)
 
         if status != bmc.NO_ERR:

--- a/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
+++ b/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
@@ -30,12 +30,12 @@ class BmcDeformableMirrorHardware(BmcDeformableMirror):
 
     def open(self):
         self.device = bmc.BmcDm()
-        self.device.enable_high_res(enable=self.enable_high_resolution)
         status = self.device.open_dm(self.serial_number)
 
         if status != bmc.NO_ERR:
             raise RuntimeError(f'Failed to connect: {self.dm.error_string(status)}.')
 
+        self.device.enable_high_res(enable=self.enable_high_resolution)
         self.device_command_length = self.device.num_actuators()
 
         super().open()


### PR DESCRIPTION
Default set to `False`.

Untested as THD2 doesn't have the DMs connected yet.