### PR TITLE
Add service_type input to BMC child class init

### DIFF
--- a/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
+++ b/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
@@ -17,8 +17,8 @@ except ImportError:
 
 
 class BmcDeformableMirrorHardware(BmcDeformableMirror):
-    def __init__(self):
-        super().__init__('bmc_deformable_mirror_hardware')
+    def __init__(self, service_type='bmc_deformable_mirror_hardware'):
+        super().__init__(service_type)
 
         self.device_command_index = self.config.get('device_command_index', 0)
         self.enable_high_resolution = self.config.get('enable_high_resolution', False)

--- a/catkit2/services/bmc_deformable_mirror_sim/bmc_deformable_mirror_sim.py
+++ b/catkit2/services/bmc_deformable_mirror_sim/bmc_deformable_mirror_sim.py
@@ -3,8 +3,8 @@ import threading
 
 
 class BmcDeformableMirrorSim(BmcDeformableMirror):
-    def __init__(self):
-        super().__init__('bmc_deformable_mirror_sim')
+    def __init__(self, service_type='bmc_deformable_mirror_sim'):
+        super().__init__(service_type)
 
         self.lock = threading.Lock()
 


### PR DESCRIPTION
For THD2, we need to overwrite the voltage and discretized_surface properties in the BMC classes since we don't use gain maps. Instead, our surface to voltage conversion is given by a functional relationship. See https://github.com/ivalaginja/thd-controls/pull/300.

This is easy to do, however, we'd need the hw and sim classes of the BMC services in catkit2 to allow us to call the super init with a `service_type`, like added in this PR. I gave it a default value so that they can still be used directly.

I tested this in simulation and it works.

@ehpor would this be an acceptable change?