### PR TITLE
MNT: Replace ubuntu-20.04 with ubuntu-22.04

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: ".github/workflows" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build_docs
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
       with:
-        python-version: '3.7.6'
+        python-version: '3.12'
     - name: Install flake8
       run: |
         python -m pip install flake8

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,8 +2,6 @@ name: Linting
 
 on:
   workflow_dispatch:
-    branches:
-      - develop
   pull_request:
     types: [opened, synchronize, ready_for_review]
     branches:
@@ -12,7 +10,7 @@ on:
 jobs:
   linter:
     name: Flake8
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
As recommended by actions/runner-images#11101 , this PR replaces the deprecated ubuntu-20.04 runner with a newer version. This also replaces RTD workflow, if applicable, to future-proof the build in case it follows suit.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.

[:ghost:](https://github.com/pllim/playpen/issues/63)