### PR TITLE
Add PCIe device id choice to DM startup

### DIFF
--- a/catkit2/base_services/bmc_deformable_mirror.py
+++ b/catkit2/base_services/bmc_deformable_mirror.py
@@ -10,6 +10,7 @@ class BmcDeformableMirror(DeformableMirrorService):
         super().__init__(service_type)
 
         self.serial_number = self.config['serial_number']
+        self.device_id = self.config.get('device_id', 0)
         self.flat_map_fname = self.config['flat_map_fname']
         self.gain_map_fname = self.config['gain_map_fname']
         self.max_volts = self.config['max_volts']

--- a/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
+++ b/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
@@ -21,6 +21,7 @@ class BmcDeformableMirrorHardware(BmcDeformableMirror):
     def __init__(self, service_type='bmc_deformable_mirror_hardware'):
         super().__init__(service_type)
 
+        self.device_id = self.config.get('device_id')
         self.device_command_index = self.config.get('device_command_index', 0)
         self.enable_high_resolution = self.config.get('enable_high_resolution', False)
 
@@ -31,6 +32,7 @@ class BmcDeformableMirrorHardware(BmcDeformableMirror):
 
     def open(self):
         self.device = bmc.BmcDm()
+        status1 = self.device.set_device_id(self.device_id)
         status = self.device.open_dm(self.serial_number)
 
         if status != bmc.NO_ERR:

--- a/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
+++ b/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
@@ -21,7 +21,6 @@ class BmcDeformableMirrorHardware(BmcDeformableMirror):
     def __init__(self, service_type='bmc_deformable_mirror_hardware'):
         super().__init__(service_type)
 
-        self.device_id = self.config.get('device_id')
         self.device_command_index = self.config.get('device_command_index', 0)
         self.enable_high_resolution = self.config.get('enable_high_resolution', False)
 

--- a/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
+++ b/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
@@ -31,9 +31,12 @@ class BmcDeformableMirrorHardware(BmcDeformableMirror):
 
     def open(self):
         self.device = bmc.BmcDm()
-        status1 = self.device.set_device_id(self.device_id)
-        status = self.device.open_dm(self.serial_number)
 
+        status1 = self.device.set_device_id(self.device_id)
+        if status1 != None:
+            pass
+
+        status = self.device.open_dm(self.serial_number)
         if status != bmc.NO_ERR:
             raise RuntimeError(f'Failed to connect: {self.dm.error_string(status)}.')
 

--- a/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
+++ b/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
@@ -32,13 +32,13 @@ class BmcDeformableMirrorHardware(BmcDeformableMirror):
     def open(self):
         self.device = bmc.BmcDm()
 
-        status1 = self.device.set_device_id(self.device_id)
-        if status1 != None:
-            pass
+        pcie_status = self.device.set_device_id(self.device_id)
+        if pcie_status != bmc.NO_ERR:
+            raise RuntimeError(f'Failed to connect: {self.dm.error_string(pcie_status)}.')
 
-        status = self.device.open_dm(self.serial_number)
-        if status != bmc.NO_ERR:
-            raise RuntimeError(f'Failed to connect: {self.dm.error_string(status)}.')
+        dm_status = self.device.open_dm(self.serial_number)
+        if dm_status != bmc.NO_ERR:
+            raise RuntimeError(f'Failed to connect: {self.dm.error_string(dm_status)}.')
 
         self.device.enable_high_res(enable=self.enable_high_resolution)
         self.device_command_length = self.device.num_actuators()


### PR DESCRIPTION
When more than one PCIe card for separate DMs is used on a single machine, the DM serial number is not enough to identify the connection. The device ID of the corresponding PCIe card needs to be provided to the BMC device prior to opening it, as documented in the `bmc` module.

This PR adds this functionality, with a default to ignore itself if no PCIe device ID is provided, in which case the controller automatically connects to the only card available.

Important:
https://github.com/spacetelescope/catkit2/pull/287#issuecomment-2653934895