### PR TITLE
Add line to installation.rst describing how to increase ulimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,15 @@ Finally install the package using:
 pip install -e .
 cd ..
 ```
+
+If using MacOS 15.3.1 (Sequoia) be sure to add the following line to your
+``.bash_profle`` (or the profile of your terminal if not using bash) to increase 
+the default resources available to processes set by the OS. The default for Sequoia 
+is 256 and a value of at least 2000 is recommended. Most people find 4096 to be 
+sufficient.
+
+.. code-block:: bash
+
+    ulimit -n <number>
+
+See Installation documentation for more details.  

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -37,7 +37,8 @@ Some services require manual installation of their respective drivers to access 
 On MacOS 15.3.1 (Sequoia) a "too many open files error" can be seen due to the default resources
 available to processes set by the OS. This value can be increased manually using the ``ulimit``
 command that can be executed on terminal startup by adding the following line to your
-``.bash_profle``. The default for Sequoia is 256 and a value of at least 2000 is recommended.
+``.bash_profle`` (or the profile of your terminal if not using bash). The default for Sequoia is 256
+and a value of at least 2000 is recommended.
 
 .. code-block:: bash
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -38,8 +38,10 @@ On MacOS 15.3.1 (Sequoia) a "too many open files error" can be seen due to the d
 available to processes set by the OS. This value can be increased manually using the ``ulimit``
 command that can be executed on terminal startup by adding the following line to your
 ``.bash_profle`` (or the profile of your terminal if not using bash). The default for Sequoia is 256
-and a value of at least 2000 is recommended.
+and a value of at least 2000 is recommended. Most people find 4096 to be sufficient.
 
 .. code-block:: bash
 
     ulimit -n <number>
+
+Note: This issue is OS version dependent and might need to be revisited.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -33,3 +33,12 @@ You should see the main compilation complete in the terminal output without erro
     pip install -e .
 
 Some services require manual installation of their respective drivers to access the devices that they operate.
+
+On MacOS 15.3.1 (Sequoia) a "too many open files error" can be seen due to the default resources
+available to processes set by the OS. This value can be increased manually using the ``ulimit``
+command that can be executed on terminal startup by adding the following line to your
+``.bash_profle``. The default for Sequoia is 256 and a value of at least 2000 is recommended.
+
+.. code-block:: bash
+
+    ulimit -n <number>


### PR DESCRIPTION
Adds a few lines of docs describing how to increase the ulimit on MacOS upon opening a terminal so you do not have to do it manually. This solves the "too many open files" error encountered upon running services with many processes. 