### PR TITLE
Added missing standard libraries (string, stdint e.t.c.) to .cpp and header files 

### DIFF
--- a/benchmarks/datastream_latency.cpp
+++ b/benchmarks/datastream_latency.cpp
@@ -6,6 +6,7 @@
 #include <numeric>
 #include <fstream>
 #include <atomic>
+#include <cstdint>
 
 #include "DataStream.h"
 #include "Timing.h"

--- a/benchmarks/hash_map.cpp
+++ b/benchmarks/hash_map.cpp
@@ -2,6 +2,8 @@
 #include "Timing.h"
 
 #include <iostream>
+#include <cstdint>
+#include <string>
 
 int main(int argc, char **argv)
 {

--- a/catkit2/bindings.cpp
+++ b/catkit2/bindings.cpp
@@ -4,6 +4,9 @@
 #include <pybind11/functional.h>
 #include <pybind11_json/pybind11_json.hpp>
 #include <cctype>
+#include <string>
+#include <vector>
+#include <variant>
 
 #include "DataStream.h"
 #include "Timing.h"

--- a/catkit_core/Client.cpp
+++ b/catkit_core/Client.cpp
@@ -10,6 +10,8 @@
 #include <chrono>
 #include <thread>
 #include <iostream>
+#include <string>
+#include <mutex>
 
 using namespace std;
 using namespace zmq;

--- a/catkit_core/Command.cpp
+++ b/catkit_core/Command.cpp
@@ -1,5 +1,7 @@
 #include "Command.h"
 
+#include <string>
+
 Command::Command(std::string name, CommandFunction command)
 	: m_Name(name), m_CommandFunction(command)
 {

--- a/catkit_core/DataStream.cpp
+++ b/catkit_core/DataStream.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <sstream>
 #include <iomanip>
+#include <string>
 
 #ifndef _WIN32
 	#include <sys/mman.h>

--- a/catkit_core/DataStream.h
+++ b/catkit_core/DataStream.h
@@ -5,6 +5,8 @@
 #include <map>
 #include <vector>
 #include <climits>
+#include <cstdint>
+#include <string>
 
 #include "SharedMemory.h"
 #include "Event.h"

--- a/catkit_core/EventBase.h
+++ b/catkit_core/EventBase.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <stdexcept>
 #include <memory>
+#include <string>
 
 enum class EventImplementationType
 {

--- a/catkit_core/EventConditionVariable.inl
+++ b/catkit_core/EventConditionVariable.inl
@@ -2,6 +2,8 @@
 
 #include "Timing.h"
 
+#include <string>
+
 #if defined(__linux__) || defined(__APPLE__)
 	#include <pthread.h>
 #endif

--- a/catkit_core/EventSemaphore.inl
+++ b/catkit_core/EventSemaphore.inl
@@ -2,6 +2,8 @@
 
 #include "Timing.h"
 
+#include <string>
+
 #ifdef _WIN32
 	#define WIN32_LEAN_AND_MEAN
 	#define NOMINMAX

--- a/catkit_core/FreeListAllocator.h
+++ b/catkit_core/FreeListAllocator.h
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <cstdint>
 #include <memory>
+#include <cstdint>
 
 // A simple lock-free free list allocator.
 class FreeListAllocator : public ShareableImpl<ShareableType::FreeListAllocator>

--- a/catkit_core/HostName.cpp
+++ b/catkit_core/HostName.cpp
@@ -1,6 +1,6 @@
 #include "HostName.h"
 
-#include <cstring>
+#include <string>
 #include <locale>
 
 #ifdef _WIN32

--- a/catkit_core/HostName.cpp
+++ b/catkit_core/HostName.cpp
@@ -1,6 +1,6 @@
 #include "HostName.h"
 
-#include <string>
+#include <cstring>
 #include <locale>
 
 #ifdef _WIN32

--- a/catkit_core/Log.cpp
+++ b/catkit_core/Log.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <string>
 
 using namespace std;
 

--- a/catkit_core/Log.h
+++ b/catkit_core/Log.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <cstdint>
 
 #ifndef LOG_LEVEL
 	#define LOG_LEVEL 5

--- a/catkit_core/LogForwarder.cpp
+++ b/catkit_core/LogForwarder.cpp
@@ -2,6 +2,8 @@
 
 #include <nlohmann/json.hpp>
 #include <iostream>
+#include <string> 
+#include <thread>
 
 using namespace zmq;
 using json = nlohmann::json;

--- a/catkit_core/LoggingProxy.h
+++ b/catkit_core/LoggingProxy.h
@@ -4,6 +4,7 @@
 #include "Log.h"
 #include "TestbedProxy.h"
 
+#include <string>
 class LoggingProxy
 {
 public:

--- a/catkit_core/LoggingProxy.h
+++ b/catkit_core/LoggingProxy.h
@@ -5,6 +5,7 @@
 #include "TestbedProxy.h"
 
 #include <string>
+
 class LoggingProxy
 {
 public:

--- a/catkit_core/Property.cpp
+++ b/catkit_core/Property.cpp
@@ -1,5 +1,7 @@
 #include "Property.h"
 
+#include <string>
+
 Property::Property(std::string name, std::shared_ptr<DataStream> stream, Getter getter, Setter setter)
 	: m_Name(name), m_DataStream(stream), m_Getter(getter), m_Setter(setter)
 {

--- a/catkit_core/Server.cpp
+++ b/catkit_core/Server.cpp
@@ -11,6 +11,7 @@
 #include <chrono>
 #include <thread>
 #include <iostream>
+#include <string>
 
 using namespace std;
 using namespace zmq;

--- a/catkit_core/Service.cpp
+++ b/catkit_core/Service.cpp
@@ -13,6 +13,9 @@
 #include <iostream>
 #include <memory>
 #include <zmq_addon.hpp>
+#include <cstdint>
+#include <string>
+#include <thread>
 
 using namespace std;
 using namespace zmq;

--- a/catkit_core/ServiceProxy.cpp
+++ b/catkit_core/ServiceProxy.cpp
@@ -7,6 +7,7 @@
 #include "service.pb.h"
 
 #include <iostream>
+#include <string>
 
 using namespace std::string_literals;
 

--- a/catkit_core/ServiceProxy.h
+++ b/catkit_core/ServiceProxy.h
@@ -10,6 +10,8 @@
 #include <nlohmann/json.hpp>
 
 #include <string>
+#include <cstdint>
+#include <vector>
 
 class TestbedProxy;
 

--- a/catkit_core/SharedMemory.cpp
+++ b/catkit_core/SharedMemory.cpp
@@ -4,6 +4,7 @@
 
 #include <stdexcept>
 #include <iostream>
+#include <string>
 
 SharedMemory::~SharedMemory()
 {

--- a/catkit_core/Tensor.inl
+++ b/catkit_core/Tensor.inl
@@ -1,6 +1,8 @@
 #include "Log.h"
 
 #include <type_traits>
+#include <cstdint>
+#include <complex>
 
 template<typename T>
 constexpr DataType GetDataType()

--- a/catkit_core/Tracing.h
+++ b/catkit_core/Tracing.h
@@ -6,6 +6,9 @@
 #include <queue>
 #include <condition_variable>
 #include <variant>
+#include <cstdint>
+#include <string>
+#include <mutex>
 
 struct TraceEventInterval
 {

--- a/catkit_core/Types.cpp
+++ b/catkit_core/Types.cpp
@@ -1,4 +1,5 @@
 #include "Types.h"
+#include <string>
 
 void ToProto(const Value &value, catkit_proto::Value *proto_value)
 {

--- a/catkit_core/Types.cpp
+++ b/catkit_core/Types.cpp
@@ -1,4 +1,5 @@
 #include "Types.h"
+
 #include <string>
 
 void ToProto(const Value &value, catkit_proto::Value *proto_value)


### PR DESCRIPTION
The current setup works with older compiler versions (see the conversation in #293) but with newer versions, the compilation will fail because some standard libraries were missing in .cpp and header files. 

**Changes I made**
Add standard libraries in .cpp and .h files which will need them. @ehpor please check if there were too many redundancies because I added libs even though it was added to header files. 


