### PR TITLE
Fix compiler warning message.

### DIFF
--- a/catkit_core/ServiceProxy.cpp
+++ b/catkit_core/ServiceProxy.cpp
@@ -8,6 +8,7 @@
 
 #include <iostream>
 #include <string>
+#include <stdexcept>
 
 using namespace std::string_literals;
 
@@ -61,6 +62,8 @@ Value ServiceProxy::GetProperty(const std::string &name, void (*error_check)())
 					return ((std::int64_t *) frame.GetData())[0];
 				case DataType::DT_FLOAT64:
 					return ((double *) frame.GetData())[0];
+				default:
+					throw std::logic_error("This should be unreachable.");
 			}
 		}
 		catch (std::runtime_error)


### PR DESCRIPTION
Not all possible cases in the switch statement were listed. Other cases were unreachable, but the compiler doesn't know that. This PR adds an exception throw to make this clear.

Warning that is now fixed:
```
  [37/51] /Library/Developer/CommandLineTools/usr/bin/clang++ -DPROTOBUF_USE_DLLS -I/var/folders/_3/tqcb9bj94nd9xz_wqt4_3g2h0000gn/T/tmpg3vsvwxv/build/catkit_core/gen -isystem /Users/epor/anaconda3/envs/catkit2_test3/include -isystem /Users/epor/anaconda3/envs/catkit2_test3/include/eigen3 -O3 -DNDEBUG -std=gnu++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.0.sdk -mmacosx-version-min=14.7 -fPIC -MD -MT catkit_core/CMakeFiles/catkit_core.dir/ServiceProxy.cpp.o -MF catkit_core/CMakeFiles/catkit_core.dir/ServiceProxy.cpp.o.d -o catkit_core/CMakeFiles/catkit_core.dir/ServiceProxy.cpp.o -c /Users/epor/Github/catkit2/catkit_core/ServiceProxy.cpp
  /Users/epor/Github/catkit2/catkit_core/ServiceProxy.cpp:58:18: warning: 11 enumeration values not handled in switch: 'DT_UINT8', 'DT_UINT16', 'DT_UINT32'... [-Wswitch]
     58 |                         switch (frame.GetDataType())
        |                                 ~~~~~~^~~~~~~~~~~~~
  /Users/epor/Github/catkit2/catkit_core/ServiceProxy.cpp:58:18: note: add missing switch cases
     58 |                         switch (frame.GetDataType())
        |                                       ^
     59 |                         {
     60 |                                 case DataType::DT_INT64:
     61 |                                         return ((std::int64_t *) frame.GetData())[0];
     62 |                                 case DataType::DT_FLOAT64:
     63 |                                         return ((double *) frame.GetData())[0];
     64 |                         }
  1 warning generated.
```