### PR TITLE
Improve timestamps to ns-resolution.

### DIFF
--- a/catkit_core/Timing.cpp
+++ b/catkit_core/Timing.cpp
@@ -3,14 +3,96 @@
 #include <sstream>
 #include <iomanip>
 #include <sstream>
+#include <cstdint>
+#include <ctime>
+
+#if defined(__linux)
+	#ifdef CLOCK_MONOTONIC
+		#define CLOCKID CLOCK_MONOTONIC
+	#else
+		#define CLOCKID CLOCK_REALTIME
+	#endif
+#elif defined(__APPLE__)
+	#include <mach/mach_time.h>
+#elif defined(_WIN32)
+	#define WIN32_LEAN_AND_MEAN
+	#include <windows.h>
+#endif
 
 using namespace std;
 using namespace std::chrono;
 
+inline uint64_t compute_fraction(uint64_t x, uint64_t n, uint64_t d)
+{
+	// Compute x * n / d without overflowing.
+	const uint64_t q = x / d;
+	const uint64_t r = x % d;
+
+	return q * n + r * n / d;
+}
+
+uint64_t ns()
+{
+	static bool is_initialized = 0;
+
+#if defined(__APPLE__)
+	static mach_timebase_info_data_t info;
+
+	if (!is_initialized)
+	{
+		mach_timebase_info(&info);
+		is_initialized = true;
+	}
+
+	uint64_t now;
+
+	now = compute_fraction(mach_absolute_time(), info.numer, info.denom);
+
+	return now;
+#elif defined(__linux)
+	static struct timespec linux_rate;
+
+	if (!is_initialized)
+	{
+	  clock_getres(CLOCKID, &linux_rate);
+	  is_initialized = true;
+	}
+
+	uint64_t now;
+
+	struct timespec spec;
+	clock_gettime(CLOCKID, &spec);
+	now = uint64_t(spec.tv_sec) * 1000000000 + spec.tv_nsec;
+
+	return now;
+#elif defined(_WIN32)
+	static LARGE_INTEGER win_frequency;
+
+	if (!is_initialized)
+	{
+		QueryPerformanceFrequency(&win_frequency);
+		is_initialized = true;
+	}
+
+	LARGE_INTEGER now;
+	QueryPerformanceCounter(&now);
+
+	return compute_fraction(now.QuadPart, 1000000000, win_frequency.QuadPart);
+#else
+	return 0
+#endif
+}
+
 uint64_t GetTimeStamp()
 {
-	auto time_since_epoch = system_clock::now().time_since_epoch();
-	return duration_cast<nanoseconds>(time_since_epoch).count();
+	// Perform correction of ns() to get the correct epoch.
+	static auto before_ns = duration_cast<nanoseconds>(system_clock::now().time_since_epoch()).count();
+	static auto epoch_of_ns = ns();
+	static auto after_ns = duration_cast<nanoseconds>(system_clock::now().time_since_epoch()).count();
+
+	static int64_t correction = int64_t(before_ns + after_ns) / 2 - int64_t(epoch_of_ns);
+
+	return ns() + correction;
 }
 
 string ConvertTimestampToString(uint64_t timestamp)

--- a/catkit_core/Timing.cpp
+++ b/catkit_core/Timing.cpp
@@ -79,7 +79,7 @@ uint64_t ns()
 
 	return compute_fraction(now.QuadPart, 1000000000, win_frequency.QuadPart);
 #else
-	return 0
+	return duration_cast<system_clock::time_point::duration>(nanoseconds(timestamp));
 #endif
 }
 


### PR DESCRIPTION
Currently, timestamp resolution is 100ns on Windows, and 1000ns on MacOS/Linux, as far as my experience goes (this varies across machine/OS version). This PR uses platform specific code for each OS, that obtains nanosecond resolution timestamps on each OS.

Checking that timestamps are not significantly slower than before:
* MacOS: (MacOS Sonoma, Macbook M2 Pro)
  * Before: 15.4243 ns per timestamp, 1000ns resolution
  * After: 12.7537 ns per timestamp, 1ns resolution
* Windows: (Windows 11, AMD Ryzen 9 5900X 12-Core)
  * Before: 20.9528 ns per timestamp, 100ns resolution
  * After: 23.4281 ns per timestamp, 100ns resolution
* Linux: (Ubuntu Server 20.04, AMD Threadripper 5995WX)
  * Before: 20.7357 ns per timestamp, 1ns resolution
  * After: 21.4882 ns per timestamp, 1ns resolution