### PR TITLE
Fixing argument error

### DIFF
--- a/catkit2/services/oceanoptics_spectrometer_sim/oceanoptics_spectrometer_sim.py
+++ b/catkit2/services/oceanoptics_spectrometer_sim/oceanoptics_spectrometer_sim.py
@@ -94,7 +94,7 @@ class OceanOpticsSpectrometerSim(Service):
         This function is called when the service is started.
         '''
         while not self.should_shut_down:
-            intensities = self.take_one_spectrum(self.pixels_number)
+            intensities = self.take_one_spectrum()
             self.spectra.submit_data(np.array(intensities, dtype='float32'))
             self.is_saturating.submit_data(np.array([0], dtype='int8'))
 


### PR DESCRIPTION
Fixing : "TypeError: take_one_spectrum takes 1 positional argument but 2 were given" on the simulated oceanics spectrometer.