### PR TITLE
Be strict about shared memory lifetime

### DIFF
--- a/catkit_core/SharedMemory.cpp
+++ b/catkit_core/SharedMemory.cpp
@@ -47,12 +47,18 @@ SharedMemory::~SharedMemory()
 	if (m_Buffer)
 	{
 #ifdef _WIN32
+		// Unmap the view of the file.
 		UnmapViewOfFile(m_Buffer);
+
+		// Close the file mapping object. For Windows, once all handles are closed,
+		// the shared memory object is automatically deleted.
 		CloseHandle(m_File);
 #else
+		// Delete the shared memory object if we are the owner.
 		if (m_IsOwner)
 			shm_unlink(m_FileName.c_str());
 
+		// Unmap and close the file descriptor.
 		struct stat stat_buf;
 		fstat(m_File, &stat_buf);
 
@@ -72,24 +78,45 @@ std::shared_ptr<SharedMemory> SharedMemory::Create(std::string_view fname, size_
 	std::string fname_string = std::string(fname);
 
 #ifdef _WIN32
+	// Ensure the last error is zero before calling CreateFileMapping.
+	SetLastError(NO_ERROR);
+
+	// Create a file mapping object with the specified name.
 	FileObject file = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, (DWORD) num_bytes_in_buffer + sizeof(Header), fname_string.c_str());
 
-	if (file == NULL)
-		throw std::runtime_error("Something went wrong while creating shared memory.");
+	if (file == NULL || GetLastError() != NO_ERROR)
+	{
+		DWORD error_message_id = GetLastError();
+		std::string error_message = GetLastErrorAsString(error_message_id);
+
+		// If we were given a file handle, we should close it.
+		if (file)
+			CloseHandle(file);
+
+		throw std::runtime_error("Something went wrong while creating shared memory: " + error_message);
+	}
 #else
 	FileObject file = shm_open(fname_string.c_str(), O_CREAT | O_RDWR | O_EXCL, 0666);
 
 	if (file < 0)
-		throw std::runtime_error("Something went wrong while creating shared memory.");
+	{
+		// Throw an error containing the error message.
+		std::string error_message = ErrnoAsString(errno);
+
+		throw std::runtime_error("Something went wrong while creating shared memory: " + error_message);
+	}
 
     int res = ftruncate(file, num_bytes_in_buffer + sizeof(Header));
 
 	if (res < 0)
 	{
-		shm_unlink(fname_string.c_str());
+		// Throw an error containing the error message.
+		std::string error_message = ErrnoAsString(errno);
+
+		shm_unlink((id + ".mem").c_str());
 		close(file);
 
-		throw std::runtime_error("Something went wrong while setting the size of shared memory.");
+		throw std::runtime_error("Something went wrong while setting the size of shared memory: " + error_message);
 	}
 #endif
 
@@ -130,12 +157,23 @@ std::shared_ptr<SharedMemory> SharedMemory::Open(std::string_view fname)
 	FileObject file = OpenFileMapping(FILE_MAP_ALL_ACCESS, FALSE, fname_string.c_str());
 
 	if (file == NULL)
-		throw std::runtime_error("Something went wrong while opening shared memory.");
+	{
+		// Throw an error containing the error message.
+		DWORD error_message_id = GetLastError();
+		std::string error_message = GetLastErrorAsString(error_message_id);
+
+		throw std::runtime_error("Something went wrong while opening shared memory: " + error_message);
+	}
 #else
 	FileObject file = shm_open(fname_string.c_str(), O_RDWR, 0666);
 
 	if (file < 0)
-		throw std::runtime_error("Something went wrong while opening shared memory.");
+	{
+		// Throw an error containing the error message.
+		std::string error_message = ErrnoAsString(errno);
+
+		throw std::runtime_error("Something went wrong while opening shared memory: " + error_message);
+	}
 #endif
 
 	auto res = std::shared_ptr<SharedMemory>(new SharedMemory(fname, file, false));
@@ -161,15 +199,29 @@ SharedMemory::SharedMemory(std::string_view fname, FileObject file, bool is_owne
 {
 #ifdef _WIN32
 	m_Buffer = MapViewOfFile(m_File, FILE_MAP_ALL_ACCESS, 0, 0, 0);
+
+	if (!m_Buffer)
+	{
+		// Throw an error containing the error message.
+		DWORD error_message_id = GetLastError();
+		std::string error_message = GetLastErrorAsString(error_message_id);
+
+		throw std::runtime_error("Something went wrong while mapping shared memory file: " + error_message);
+	}
 #else
 	struct stat stat_buf;
 	fstat(m_File, &stat_buf);
 
 	m_Buffer = mmap(0, stat_buf.st_size, PROT_WRITE, MAP_SHARED, m_File, 0);
-#endif // _WIN32
 
 	if (!m_Buffer)
-		throw std::runtime_error("Something went wrong while mapping shared memory file.");
+	{
+		// Throw an error containing the error message.
+		std::string error_message = ErrnoAsString(errno);
+
+		throw std::runtime_error("Something went wrong while mapping shared memory file: " + error_message);
+	}
+#endif // _WIN32
 }
 
 void *SharedMemory::GetAddress(std::size_t offset)

--- a/catkit_core/SharedMemory.cpp
+++ b/catkit_core/SharedMemory.cpp
@@ -7,6 +7,41 @@
 #include <array>
 #include <algorithm>
 
+#ifdef _WIN32
+	//Returns the last Win32 error, in string format. Returns an empty string if there is no error.
+	std::string GetLastErrorAsString(DWORD error_message_id)
+	{
+		//Get the error message ID, if any.
+		if(error_message_id == 0) {
+			return std::string(); //No error message has been recorded
+		}
+
+		LPSTR message_buffer = nullptr;
+
+		//Ask Win32 to give us the string version of that message ID.
+		//The parameters we pass in, tell Win32 to create the buffer that holds the message for us (because we don't yet know how long the message string will be).
+		size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+			NULL, error_message_id, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR) &message_buffer, 0, NULL);
+
+		//Copy the error message into a std::string.
+		std::string message(message_buffer, size);
+
+		//Free the Win32's string's buffer.
+		LocalFree(message_buffer);
+
+		return message;
+	}
+#else
+	#include <cerrno>
+	#include <cstring>
+
+	std::string ErrnoAsString(int error_id)
+	{
+		char *e = std::strerror(error_id);
+		return e ? e : "";
+	}
+#endif
+
 SharedMemory::~SharedMemory()
 {
 	if (m_Buffer)

--- a/catkit_core/SharedMemory.cpp
+++ b/catkit_core/SharedMemory.cpp
@@ -113,7 +113,7 @@ std::shared_ptr<SharedMemory> SharedMemory::Create(std::string_view fname, size_
 		// Throw an error containing the error message.
 		std::string error_message = ErrnoAsString(errno);
 
-		shm_unlink((id + ".mem").c_str());
+		shm_unlink(fname_string.c_str());
 		close(file);
 
 		throw std::runtime_error("Something went wrong while setting the size of shared memory: " + error_message);

--- a/tests/test_shared_memory.py
+++ b/tests/test_shared_memory.py
@@ -1,0 +1,30 @@
+from catkit2.catkit_bindings import SharedMemory
+import pytest
+
+
+def test_shared_memory_lifetime():
+    stream_id = 'test_memory'
+    memory = SharedMemory.create(stream_id, 1024)
+
+    # Creating shared memory with the same ID should raise en erorr.
+    with pytest.raises(RuntimeError):
+        SharedMemory.create(stream_id, 1024)
+
+    # We should be able to access the shared memory when opening.
+    memory2 = SharedMemory.open(stream_id)
+
+    # After closing the opened memory, we should still be able to reopen it.
+    del memory2
+
+    memory2 = SharedMemory.open(stream_id)
+
+    # Delete both the created and opened memory.
+    del memory
+    del memory2
+
+    # Now we should not be able to open the shared memory anymore.
+    with pytest.raises(RuntimeError):
+        SharedMemory.open(stream_id)
+
+    # However, we should be able to create a new shared memory with the same ID.
+    memory = SharedMemory.create(stream_id, 1024)


### PR DESCRIPTION
> [!CAUTION]
> This PR requires #272 to be merged before.

This replaces #112.

This PR is to explicitly prohibit creating a new shared memory object with a certain ID, when one already exists. This is not allowed on Linux/MacOS but was allowed on Windows until now (due to me not correctly checking the error output). This PR performs stricter error checks. Simultaneously, all error values are now checked and the exceptions now contain text containing the exact error that was encountered rather than a generic message.