### PR TITLE
Add a benchmark for latency for events.

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -54,6 +54,11 @@ add_executable(hybrid_pool_allocator hybrid_pool_allocator.cpp)
 target_include_directories(hybrid_pool_allocator PUBLIC ../catkit_core)
 target_link_libraries(hybrid_pool_allocator PUBLIC catkit_core)
 
+# Event latency benchmark
+add_executable(event_latency event_latency.cpp)
+target_include_directories(event_latency PUBLIC ../catkit_core)
+target_link_libraries(event_latency PUBLIC catkit_core)
+
 # Add install files
 install(TARGETS datastream_latency DESTINATION bin)
 install(TARGETS datastream_submit DESTINATION bin)
@@ -64,3 +69,4 @@ install(TARGETS uuid_generator DESTINATION bin)
 install(TARGETS message_broker DESTINATION bin)
 install(TARGETS buddy_allocator DESTINATION bin)
 install(TARGETS hybrid_pool_allocator DESTINATION bin)
+install(TARGETS event_latency DESTINATION bin)

--- a/benchmarks/event_latency.cpp
+++ b/benchmarks/event_latency.cpp
@@ -25,11 +25,14 @@ void SetThreadAffinity(int core_id)
 #ifdef _WIN32
 	DWORD_PTR mask = 1ULL << core_id;
 	SetThreadAffinityMask(GetCurrentThread(), mask);
-#else
+#elif __linux__
 	cpu_set_t cpuset;
 	CPU_ZERO(&cpuset);
 	CPU_SET(core_id, &cpuset);
 	pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
+#else
+	// MacOS and other platforms may not support thread affinity in the same way.
+	std::err << "Thread affinity is not supported on this platform." << std::endl;
 #endif
 }
 

--- a/benchmarks/event_latency.cpp
+++ b/benchmarks/event_latency.cpp
@@ -113,7 +113,7 @@ void receive(size_t core_id, EventWaitMethod method)
 
 void print_usage()
 {
-	std::cerr << "Usage: event_latency (default | semaphore | futex | spinlock)" << std::endl;
+	std::cerr << "Usage: event_latency (default | condition_variable | semaphore | futex | spinlock)" << std::endl;
 }
 
 int main(int argc, char *argv[])
@@ -130,6 +130,10 @@ int main(int argc, char *argv[])
 	if (wait_method_str == "default")
 	{
 		wait_method = EventWaitMethod::Default;
+	}
+	else if (wait_method_str == "condition_variable")
+	{
+		wait_method = EventWaitMethod::ConditionVariable;
 	}
 	else if (wait_method_str == "semaphore")
 	{

--- a/benchmarks/event_latency.cpp
+++ b/benchmarks/event_latency.cpp
@@ -104,7 +104,8 @@ void receive(size_t core_id, EventWaitMethod method)
 	double sq_sum = std::inner_product(latencies.begin(), latencies.end(), latencies.begin(), 0.0);
 	double stdev = std::sqrt(sq_sum / latencies.size() - mean * mean);
 
-	std::cout << mean << ", ";//" +/- " << stdev << " ns" << std::endl;
+	std::cout << mean;
+}
 }
 
 void main()
@@ -139,6 +140,14 @@ void main()
 
 				submit_thread.join();
 				receive_thread.join();
+
+			if (j != num_cores - 1)
+			{
+				std::cout << ", ";
+			}
+			else
+			{
+				std::cout << std::endl;
 			}
 		}
 	}

--- a/benchmarks/event_latency.cpp
+++ b/benchmarks/event_latency.cpp
@@ -32,7 +32,7 @@ void SetThreadAffinity(int core_id)
 	pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
 #else
 	// MacOS and other platforms may not support thread affinity in the same way.
-	std::err << "Thread affinity is not supported on this platform." << std::endl;
+	std::cerr << "Thread affinity is not supported on this platform." << std::endl;
 #endif
 }
 
@@ -71,10 +71,7 @@ void submit(size_t core_id)
 		auto timestamp = GetTimeStamp();
 		timestamp_start.store(timestamp, std::memory_order_relaxed);
 
-		{
-			EventLockGuard lock(event);
-			event->Signal();
-		}
+		event->Signal();
 	}
 }
 
@@ -92,14 +89,11 @@ void receive(size_t core_id, EventWaitMethod method)
 	{
 		ready = true;
 
+		// Wait for the event to be signaled.
+		event->Wait(2, []()
 		{
-			EventLockGuard lock(event);
-
-			// Wait for the event to be signaled.
-			event->Wait(2, []() {
-				return !ready;
-			}, method);
-		}
+			return !ready;
+		}, method);
 
 		auto timestamp_end = GetTimeStamp();
 		latencies[i] = double(timestamp_end) - double(timestamp_start.load(std::memory_order_relaxed));

--- a/benchmarks/event_latency.cpp
+++ b/benchmarks/event_latency.cpp
@@ -116,13 +116,13 @@ void print_usage()
 	std::cerr << "Usage: event_latency (default | semaphore | futex | spinlock)" << std::endl;
 }
 
-void main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
 	// Parse argument.
 	if (argc < 2)
 	{
 		print_usage();
-		return;
+		return 1;
 	}
 
 	std::string wait_method_str = argv[1];
@@ -146,7 +146,7 @@ void main(int argc, char *argv[])
 	else
 	{
 		print_usage();
-		return;
+		return 2;
 	}
 
 	// Create the buffer.
@@ -185,4 +185,6 @@ void main(int argc, char *argv[])
 	}
 
 	delete[] buffer;
+
+	return 0;
 }

--- a/benchmarks/event_latency.cpp
+++ b/benchmarks/event_latency.cpp
@@ -110,40 +110,68 @@ void receive(size_t core_id, EventWaitMethod method)
 
 	std::cout << mean;
 }
+
+void print_usage()
+{
+	std::cerr << "Usage: event_latency (default | semaphore | futex | spinlock)" << std::endl;
 }
 
-void main()
+void main(int argc, char *argv[])
 {
-	std::cout << "Event latency benchmark." << std::endl;
+	// Parse argument.
+	if (argc < 2)
+	{
+		print_usage();
+		return;
+	}
+
+	std::string wait_method_str = argv[1];
+	EventWaitMethod wait_method;
+	if (wait_method_str == "default")
+	{
+		wait_method = EventWaitMethod::Default;
+	}
+	else if (wait_method_str == "semaphore")
+	{
+		wait_method = EventWaitMethod::Semaphore;
+	}
+	else if (wait_method_str == "futex")
+	{
+		wait_method = EventWaitMethod::Futex;
+	}
+	else if (wait_method_str == "spinlock")
+	{
+		wait_method = EventWaitMethod::SpinLock;
+	}
+	else
+	{
+		print_usage();
+		return;
+	}
 
 	// Create the buffer.
 	buffer = new char[1024 * 1024];
 
 	std::size_t num_cores = std::thread::hardware_concurrency();
-	std::cout << "Number of cores: " << num_cores << std::endl;
 
-	for (auto method : {EventWaitMethod::Default, EventWaitMethod::SpinLock})
+	for (std::size_t i = 0; i < num_cores; ++i)
 	{
-		std::cout << "Method: " << static_cast<int>(method) << std::endl;
-
-		for (std::size_t i = 0; i < num_cores; ++i)
+		for (std::size_t j = 0; j < num_cores; ++j)
 		{
-			for (std::size_t j = 0; j < num_cores; ++j)
+			ready = false;
+
+			auto receive_thread = std::thread(receive, j, wait_method);
+
+			// Make sure the receive thread is ready before starting the submit thread.
+			while (!ready)
 			{
-				ready = false;
+				std::this_thread::yield();
+			}
 
-				auto receive_thread = std::thread(receive, j, method);
+			auto submit_thread = std::thread(submit, i);
 
-				// Make sure the receive thread is ready before starting the submit thread.
-				while (!ready)
-				{
-					std::this_thread::yield();
-				}
-
-				auto submit_thread = std::thread(submit, i);
-
-				submit_thread.join();
-				receive_thread.join();
+			submit_thread.join();
+			receive_thread.join();
 
 			if (j != num_cores - 1)
 			{

--- a/benchmarks/event_latency.cpp
+++ b/benchmarks/event_latency.cpp
@@ -1,0 +1,147 @@
+#include "Event.h"
+#include "Timing.h"
+
+#include <thread>
+#include <atomic>
+#include <stdexcept>
+#include <iostream>
+#include <chrono>
+#include <cstdint>
+#include <cstddef>
+#include <vector>
+#include <numeric>
+#include <cmath>
+
+#include <windows.h>
+
+const size_t NUM_ITERATIONS = 100000;
+
+void SetThreadAffinity(int core_id)
+{
+#ifdef _WIN32
+	DWORD_PTR mask = 1ULL << core_id;
+	SetThreadAffinityMask(GetCurrentThread(), mask);
+#else
+	cpu_set_t cpuset;
+	CPU_ZERO(&cpuset);
+	CPU_SET(core_id, &cpuset);
+	pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
+#endif
+}
+
+void fast_sleep(std::uint64_t ns)
+{
+	auto start = GetTimeStamp();
+
+	while (GetTimeStamp() - start < ns)
+	{
+	}
+}
+
+std::atomic_bool ready = false;
+char *buffer = nullptr;
+std::atomic_uint64_t timestamp_start(0);
+
+void submit(size_t core_id)
+{
+	SetThreadAffinity(core_id);
+
+	// Create the event.
+	auto stream = StructStream(buffer);
+	auto event = Event::Open(stream);
+
+	for (size_t i = 0; i < NUM_ITERATIONS; ++i)
+	{
+		while (!ready)
+		{
+			std::this_thread::yield();
+		}
+
+		ready = false;
+
+		fast_sleep(1000);
+
+		auto timestamp = GetTimeStamp();
+		timestamp_start.store(timestamp, std::memory_order_relaxed);
+
+		{
+			EventLockGuard lock(event);
+			event->Signal();
+		}
+	}
+}
+
+void receive(size_t core_id, EventWaitMethod method)
+{
+	SetThreadAffinity(core_id);
+
+	// Open the event.
+	auto stream = StructStream(buffer);
+	auto event = Event::Create(stream, "test_event");
+
+	std::vector<double> latencies(NUM_ITERATIONS);
+
+	for (std::size_t i = 0; i < NUM_ITERATIONS; ++i)
+	{
+		ready = true;
+
+		{
+			EventLockGuard lock(event);
+
+			// Wait for the event to be signaled.
+			event->Wait(2, []() {
+				return !ready;
+			}, method);
+		}
+
+		auto timestamp_end = GetTimeStamp();
+		latencies[i] = double(timestamp_end) - double(timestamp_start.load(std::memory_order_relaxed));
+	}
+
+	double sum = std::accumulate(latencies.begin(), latencies.end(), 0.0);
+	double mean = sum / latencies.size();
+
+	double sq_sum = std::inner_product(latencies.begin(), latencies.end(), latencies.begin(), 0.0);
+	double stdev = std::sqrt(sq_sum / latencies.size() - mean * mean);
+
+	std::cout << mean << ", ";//" +/- " << stdev << " ns" << std::endl;
+}
+
+void main()
+{
+	std::cout << "Event latency benchmark." << std::endl;
+
+	// Create the buffer.
+	buffer = new char[1024 * 1024];
+
+	std::size_t num_cores = std::thread::hardware_concurrency();
+	std::cout << "Number of cores: " << num_cores << std::endl;
+
+	for (auto method : {EventWaitMethod::Default, EventWaitMethod::SpinLock})
+	{
+		std::cout << "Method: " << static_cast<int>(method) << std::endl;
+
+		for (std::size_t i = 0; i < num_cores; ++i)
+		{
+			for (std::size_t j = 0; j < num_cores; ++j)
+			{
+				ready = false;
+
+				auto receive_thread = std::thread(receive, j, method);
+
+				// Make sure the receive thread is ready before starting the submit thread.
+				while (!ready)
+				{
+					std::this_thread::yield();
+				}
+
+				auto submit_thread = std::thread(submit, i);
+
+				submit_thread.join();
+				receive_thread.join();
+			}
+		}
+	}
+
+	delete[] buffer;
+}

--- a/benchmarks/event_latency.cpp
+++ b/benchmarks/event_latency.cpp
@@ -12,7 +12,11 @@
 #include <numeric>
 #include <cmath>
 
+#ifdef _WIN32
 #include <windows.h>
+#else
+#include <pthread.h>
+#endif
 
 const size_t NUM_ITERATIONS = 100000;
 

--- a/catkit2/bindings.cpp
+++ b/catkit2/bindings.cpp
@@ -1031,16 +1031,7 @@ PYBIND11_MODULE(catkit_bindings, m)
 				return py::cast<bool>(condition());
 			}, wait_method, error_check_python);
 		}, py::arg("condition"), py::arg("timeout_in_sec") = -1, py::arg("wait_method") = EventWaitMethod::Default, py::call_guard<py::gil_scoped_release>())
-		.def("signal", &Event::Signal, py::call_guard<py::gil_scoped_release>())
-		.def("__enter__", [](std::shared_ptr<Event> event)
-		{
-			event->Lock();
-			return event;
-		}, py::call_guard<py::gil_scoped_release>())
-		.def("__exit__", [] (std::shared_ptr<Event> event, const std::optional<pybind11::type> &exc_type, const std::optional<pybind11::object> &exc_value, const std::optional<pybind11::object> &traceback)
-		{
-			event->Unlock();
-		}, py::call_guard<py::gil_scoped_release>());
+		.def("signal", &Event::Signal, py::call_guard<py::gil_scoped_release>());
 
 	py::enum_<MessageSubscriptionMode>(m, "MessageSubscriptionMode")
 		.value("NewestOnly", MessageSubscriptionMode::NewestOnly)

--- a/catkit_core/DataStream.cpp
+++ b/catkit_core/DataStream.cpp
@@ -205,24 +205,18 @@ void DataStream::SubmitFrame(size_t id)
 	DataFrameMetadata *meta = m_Header->m_FrameMetadata + (id % m_Header->m_NumFramesInBuffer);
 	meta->m_TimeStamp = GetTimeStamp();
 
+	// Make frame available:
+	// Use a do-while loop to ensure we are never decrementing the last id.
+	size_t last_id;
+	do
 	{
-		// Obtain a lock as we are about to modify the condition of the
-		// synchronization.
-		auto lock = EventLockGuard(m_Event);
+		last_id = m_Header->m_LastId;
 
-		// Make frame available:
-		// Use a do-while loop to ensure we are never decrementing the last id.
-		size_t last_id;
-		do
-		{
-			last_id = m_Header->m_LastId;
+		if (last_id >= id + 1)
+			break;
+	} while (!m_Header->m_LastId.compare_exchange_strong(last_id, id + 1));
 
-			if (last_id >= id + 1)
-				break;
-		} while (!m_Header->m_LastId.compare_exchange_strong(last_id, id + 1));
-
-		m_Event->Signal();
-	}
+	m_Event->Signal();
 
 	auto ts = GetTimeStamp();
 	tracing_proxy.TraceInterval("DataStream::SubmitFrame", GetStreamName(), ts, 0);
@@ -365,8 +359,6 @@ DataFrame DataStream::GetFrame(size_t id, long wait_time_in_ms, void (*error_che
 			throw std::runtime_error("Frame is not available yet.");
 
 		// Wait until frame becomes available.
-		// Obtain a lock first.
-		auto lock = EventLockGuard(m_Event);
 		m_Event->Wait(wait_time_in_ms / 1000.0, [this, id]() { return this->m_Header->m_LastId > id; }, EventWaitMethod::Default, error_check);
 	}
 

--- a/catkit_core/Event.cpp
+++ b/catkit_core/Event.cpp
@@ -41,24 +41,6 @@ void Event::Signal()
 	m_ConditionVariable->Signal();
 }
 
-void Event::Lock()
-{
-	// Lock all event types.
-	m_SpinLock->Lock();
-	m_Futex->Lock();
-	m_Semaphore->Lock();
-	m_ConditionVariable->Lock();
-}
-
-void Event::Unlock()
-{
-	// Unlock all event types.
-	m_Semaphore->Unlock();
-	m_Futex->Unlock();
-	m_SpinLock->Unlock();
-	m_ConditionVariable->Unlock();
-}
-
 std::shared_ptr<Event> Event::Create(StructStream &stream, std::string_view id)
 {
 	auto header = stream.Extract<Header>();

--- a/catkit_core/Event.h
+++ b/catkit_core/Event.h
@@ -8,25 +8,6 @@
 #include <memory>
 #include <array>
 
-template <typename Event>
-class EventLockGuard
-{
-public:
-	inline EventLockGuard(Event &event)
-		: m_Event(event)
-	{
-		m_Event->Lock();
-	}
-
-	inline ~EventLockGuard()
-	{
-		m_Event->Unlock();
-	}
-
-private:
-	Event &m_Event;
-};
-
 enum class EventWaitMethod
 {
 	Default,
@@ -54,9 +35,6 @@ private:
 public:
 	void Wait(double timeout_in_sec, std::function<bool()> condition, EventWaitMethod wait_method = EventWaitMethod::Default, void (*error_check)() = nullptr);
 	void Signal();
-
-	void Lock();
-	void Unlock();
 
 	static std::shared_ptr<Event> Create(StructStream &stream, std::string_view id);
 	static std::shared_ptr<Event> Open(StructStream &stream);

--- a/catkit_core/EventBase.h
+++ b/catkit_core/EventBase.h
@@ -45,9 +45,6 @@ public:
 	inline void Wait(double timeout_in_sec, std::function<bool()> condition, void (*error_check)());
 	inline void Signal();
 
-	inline void Lock();
-	inline void Unlock();
-
 protected:
 	inline void CreateImpl(std::string_view id, SharedState *shared_state);
 	inline void OpenImpl(std::string_view id, SharedState *shared_state);

--- a/catkit_core/EventBase.inl
+++ b/catkit_core/EventBase.inl
@@ -23,16 +23,6 @@ void EventImpl<Type>::Signal()
 }
 
 template<enum EventImplementationType Type>
-void EventImpl<Type>::Lock()
-{
-}
-
-template<enum EventImplementationType Type>
-void EventImpl<Type>::Unlock()
-{
-}
-
-template<enum EventImplementationType Type>
 std::shared_ptr<EventImpl<Type>> EventImpl<Type>::Create(std::string_view id, EventImpl<Type>::SharedState *shared_state)
 {
 	if (!shared_state)

--- a/catkit_core/EventConditionVariable.inl
+++ b/catkit_core/EventConditionVariable.inl
@@ -19,10 +19,29 @@ struct EventSharedState<EventImplementationType::ConditionVariable>
 	pthread_cond_t m_Condition;
 };
 
+class PThreadLockGuard
+{
+public:
+	inline PThreadLockGuard(pthread_mutex_t *mutex)
+		: m_Mutex(mutex)
+	{
+		pthread_mutex_lock(m_Mutex);
+	}
+
+	inline ~PThreadLockGuard()
+	{
+		pthread_mutex_unlock(m_Mutex);
+	}
+
+private:
+	pthread_mutex_t *m_Mutex;
+};
+
 template<>
 inline void EventConditionVariable::Wait(double timeout_in_sec, std::function<bool()> condition, void (*error_check)())
 {
-    Timer timer;
+	Timer timer;
+	PThreadLockGuard(&m_SharedState->m_Mutex);
 
 	while (!condition())
 	{
@@ -58,25 +77,15 @@ inline void EventConditionVariable::Wait(double timeout_in_sec, std::function<bo
 template<>
 inline void EventConditionVariable::Signal()
 {
-    pthread_cond_broadcast(&(m_SharedState->m_Condition));
-}
+	PThreadLockGuard(&m_SharedState->m_Mutex);
 
-template<>
-inline void EventConditionVariable::Lock()
-{
-    pthread_mutex_lock(&(m_SharedState->m_Mutex));
-}
-
-template<>
-inline void EventConditionVariable::Unlock()
-{
-    pthread_mutex_unlock(&(m_SharedState->m_Mutex));
+	pthread_cond_broadcast(&(m_SharedState->m_Condition));
 }
 
 template<>
 inline void EventConditionVariable::CreateImpl(std::string_view id, EventConditionVariable::SharedState *shared_state)
 {
-    pthread_mutexattr_t mutex_attr;
+	pthread_mutexattr_t mutex_attr;
 	pthread_mutexattr_init(&mutex_attr);
 	pthread_mutexattr_setpshared(&mutex_attr, PTHREAD_PROCESS_SHARED);
 	pthread_mutex_init(&(shared_state->m_Mutex), &mutex_attr);

--- a/catkit_core/EventConditionVariable.inl
+++ b/catkit_core/EventConditionVariable.inl
@@ -41,7 +41,7 @@ template<>
 inline void EventConditionVariable::Wait(double timeout_in_sec, std::function<bool()> condition, void (*error_check)())
 {
 	Timer timer;
-	PThreadLockGuard(&m_SharedState->m_Mutex);
+	auto lock = PThreadLockGuard(&m_SharedState->m_Mutex);
 
 	while (!condition())
 	{
@@ -77,7 +77,7 @@ inline void EventConditionVariable::Wait(double timeout_in_sec, std::function<bo
 template<>
 inline void EventConditionVariable::Signal()
 {
-	PThreadLockGuard(&m_SharedState->m_Mutex);
+	auto lock = PThreadLockGuard(&m_SharedState->m_Mutex);
 
 	pthread_cond_broadcast(&(m_SharedState->m_Condition));
 }

--- a/catkit_core/EventSpinLock.inl
+++ b/catkit_core/EventSpinLock.inl
@@ -41,7 +41,7 @@ inline void EventSpinLock::Wait(double timeout_in_sec, std::function<bool()> con
 					error_check();
 
 				if (timer.GetTime() > timeout_in_sec)
-					throw std::runtime_error("Waiting time has expired2.");
+					throw std::runtime_error("Waiting time has expired.");
 
 				i = 0;
 

--- a/catkit_core/EventSpinLock.inl
+++ b/catkit_core/EventSpinLock.inl
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <thread>
 
 using EventSpinLock = EventImpl<EventImplementationType::SpinLock>;
 
@@ -25,7 +26,7 @@ inline void EventSpinLock::Wait(double timeout_in_sec, std::function<bool()> con
 	{
 		while (true)
 		{
-			if (m_SharedState->m_Counter.load(std::memory_order_relaxed) == current_counter)
+			if (m_SharedState->m_Counter.load(std::memory_order_acquire) != current_counter)
 				break;
 
 			if (++i == NUM_ITERATIONS_BETWEEN_CHECKS)
@@ -38,6 +39,9 @@ inline void EventSpinLock::Wait(double timeout_in_sec, std::function<bool()> con
 					throw std::runtime_error("Waiting time has expired.");
 
 				i = 0;
+
+				// Yield the thread to allow other threads to run.
+				std::this_thread::yield();
 			}
 		}
 	}
@@ -46,7 +50,7 @@ inline void EventSpinLock::Wait(double timeout_in_sec, std::function<bool()> con
 template<>
 inline void EventSpinLock::Signal()
 {
-	m_SharedState->m_Counter.fetch_add(1, std::memory_order_relaxed);
+	m_SharedState->m_Counter.fetch_add(1, std::memory_order_release);
 }
 
 template<>

--- a/catkit_core/EventSpinLock.inl
+++ b/catkit_core/EventSpinLock.inl
@@ -19,15 +19,20 @@ inline void EventSpinLock::Wait(double timeout_in_sec, std::function<bool()> con
 {
 	Timer timer;
 
-	std::size_t current_counter = m_SharedState->m_Counter.load(std::memory_order_relaxed);
+	std::size_t current_counter = m_SharedState->m_Counter.load(std::memory_order_acquire);
 	std::size_t i = 0;
 
 	while (!condition())
 	{
 		while (true)
 		{
-			if (m_SharedState->m_Counter.load(std::memory_order_acquire) != current_counter)
+			std::size_t new_counter = m_SharedState->m_Counter.load(std::memory_order_acquire);
+
+			if (new_counter != current_counter)
+			{
+				current_counter = new_counter;
 				break;
+			}
 
 			if (++i == NUM_ITERATIONS_BETWEEN_CHECKS)
 			{
@@ -36,7 +41,7 @@ inline void EventSpinLock::Wait(double timeout_in_sec, std::function<bool()> con
 					error_check();
 
 				if (timer.GetTime() > timeout_in_sec)
-					throw std::runtime_error("Waiting time has expired.");
+					throw std::runtime_error("Waiting time has expired2.");
 
 				i = 0;
 

--- a/catkit_core/MessageBroker.cpp
+++ b/catkit_core/MessageBroker.cpp
@@ -477,12 +477,7 @@ void MessageBroker::PublishMessage(Message &message, bool is_final)
 			break;
 	}
 
-	{
-		// Signal the event structure.
-		auto lock = EventLockGuard(m_Event);
-
-		m_Event->Signal();
-	}
+	m_Event->Signal();
 
 	// Deallocate the message header and payload.
 	PoolAllocator::BlockHandle message_header_index = message.m_Header - m_MessageHeaders;
@@ -864,7 +859,6 @@ Message MessageSubscription::GetNextMessage(double timeout_in_seconds, EventWait
 	}
 
 	// Otherwise, wait for it.
-	auto lock = EventLockGuard(m_MessageBroker->m_Event);
 	m_MessageBroker->m_Event->Wait(timeout_in_seconds, [this, frame_id]() { return m_TopicHeader->last_frame_id > frame_id; }, wait_type, error_check);
 
 	m_NextFrameIdToRead = frame_id + 1;

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -5,12 +5,12 @@ import pytest
 
 def event_wait(event, signal, waiting, condition):
     print(condition[0] != 0)
-    with event:
-        waiting.set()
 
-        event.wait(lambda: condition[0] != 0, 2)
+    waiting.set()
 
-        signal.set()
+    event.wait(lambda: condition[0] != 0, 2)
+
+    signal.set()
 
 def test_event():
     memory = LocalMemory.create(1024)
@@ -31,13 +31,11 @@ def test_event():
 
     # Ensure the event is not triggered unless signaled.
     with pytest.raises(RuntimeError):
-        with event:
-            event.wait(lambda: condition[0] != 0, 0.1)
+        event.wait(lambda: condition[0] != 0, 0.1)
 
     # Signal the event.
-    with event:
-        condition[0] = 1
-        event.signal()
+    condition[0] = 1
+    event.signal()
 
     # Wait for the wait to end.
     signaled.wait(1)


### PR DESCRIPTION
> [!CAUTION]
> This PR requires #272 to be merged before.

This PR adds a benchmark for measuring latency for events. This is done for all pairs of cores on the machine. Some measured graphs below on my AMD Ryzen 9 5900X to indicate why core-to-core latency measurements are important to know about.

This PR also removes explicit `Lock()` and `Unlock()` functions on the `EventImplementation`s, since this interfered with wait methods when locks are used. This PR also fixes a bug in the spin lock event implementation.

Usage: `event_latency semaphore > latency_for_semaphore.csv`

## AMD Ryzen 9 5900X (12 cores, 24 threads, Windows)

![image](https://github.com/user-attachments/assets/f46d3fa0-c977-4597-a196-804a38acb3a9)
![image](https://github.com/user-attachments/assets/f9e193f1-0ce3-4b12-be4a-91cb0d38fe36)

## AMD Ryzen Threadripper PRO 5995WX (64 cores, 24 threads, Linux)

![image](https://github.com/user-attachments/assets/71611796-5795-486e-a568-a4c46a221b27)
![image](https://github.com/user-attachments/assets/66cd5ec3-b967-4ee6-94f3-06f249fec73e)