### PR TITLE
Add an event based on futex

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -47,5 +47,5 @@ jobs:
     - name: Run tests
       run: |
         conda activate ci-env
-        pytest
+        pytest -v
       shell: bash -l {0}

--- a/catkit2/bindings.cpp
+++ b/catkit2/bindings.cpp
@@ -1033,6 +1033,23 @@ PYBIND11_MODULE(catkit_bindings, m)
 		}, py::arg("condition"), py::arg("timeout_in_sec") = -1, py::arg("wait_method") = EventWaitMethod::Default, py::call_guard<py::gil_scoped_release>())
 		.def("signal", &Event::Signal, py::call_guard<py::gil_scoped_release>());
 
+	m.def("is_wait_method_implemented", [](EventWaitMethod wait_method)
+	{
+		switch (wait_method)
+		{
+		case EventWaitMethod::Semaphore:
+			return is_event_implemented<EventImplementationType::Semaphore>::value;
+		case EventWaitMethod::ConditionVariable:
+			return is_event_implemented<EventImplementationType::ConditionVariable>::value;
+		case EventWaitMethod::Futex:
+			return is_event_implemented<EventImplementationType::Futex>::value;
+		case EventWaitMethod::SpinLock:
+			return is_event_implemented<EventImplementationType::SpinLock>::value;
+		default:
+			throw std::runtime_error("Unknown event wait method.");
+		}
+	});
+
 	py::enum_<MessageSubscriptionMode>(m, "MessageSubscriptionMode")
 		.value("NewestOnly", MessageSubscriptionMode::NewestOnly)
 		.value("Sequential", MessageSubscriptionMode::Sequential);

--- a/catkit_core/Event.cpp
+++ b/catkit_core/Event.cpp
@@ -2,16 +2,6 @@
 
 void Event::Wait(double timeout_in_sec, std::function<bool()> condition, EventWaitMethod wait_method, void (*error_check)())
 {
-	// Set default wait method.
-	if (wait_method == EventWaitMethod::Default)
-	{
-		#ifdef _WIN32
-		wait_method = EventWaitMethod::Semaphore;
-		#elif defined(__linux__) || defined(__APPLE__)
-		wait_method = EventWaitMethod::ConditionVariable;
-		#endif
-	}
-
 	// Wait for a specific event type.
 	switch (wait_method)
 	{

--- a/catkit_core/Event.h
+++ b/catkit_core/Event.h
@@ -10,11 +10,17 @@
 
 enum class EventWaitMethod
 {
-	Default,
 	ConditionVariable,
 	Futex,
 	Semaphore,
-	SpinLock
+	SpinLock,
+#ifdef _WIN32
+	Default = Semaphore
+#elif defined(__linux__)
+	Default = Futex
+#elif defined(__APPLE__)
+	Default = ConditionVariable
+#endif
 };
 
 class Event : public Shareable

--- a/catkit_core/EventBase.h
+++ b/catkit_core/EventBase.h
@@ -55,6 +55,11 @@ protected:
 	LocalState m_LocalState;
 };
 
+template<enum EventImplementationType Type>
+struct is_event_implemented : std::false_type
+{
+};
+
 #include "EventBase.inl"
 #include "EventConditionVariable.inl"
 #include "EventFutex.inl"

--- a/catkit_core/EventConditionVariable.inl
+++ b/catkit_core/EventConditionVariable.inl
@@ -13,6 +13,11 @@ using EventConditionVariable = EventImpl<EventImplementationType::ConditionVaria
 #if defined(__linux__) || defined(__APPLE__)
 
 template<>
+struct is_event_implemented<EventImplementationType::ConditionVariable> : std::true_type
+{
+};
+
+template<>
 struct EventSharedState<EventImplementationType::ConditionVariable>
 {
 	pthread_mutex_t m_Mutex;

--- a/catkit_core/EventFutex.inl
+++ b/catkit_core/EventFutex.inl
@@ -50,22 +50,37 @@ inline void EventFutex::Wait(double timeout_in_sec, std::function<bool()> condit
 		double time_remaining = timeout_in_sec - timer.GetTime();
 		double timeout_wait = std::min(0.020, time_remaining);
 
+		if (timeout_wait <= 0)
+		{
+			// The timeout expired.
+			throw std::runtime_error("Waiting time has expired.");
+		}
+
 		struct timespec timeout;
 		timeout.tv_sec = static_cast<time_t>(timeout_wait);
 		timeout.tv_nsec = 1'000'000'000 * (timeout_wait - static_cast<time_t>(timeout_wait));
 
 		if (timeout.tv_nsec >= 1'000'000'000)
 		{
-			timeout.tv_sec += static_cast<time_t>(timeout.tv_nsec / 1'000'000'000);
-			timeout.tv_nsec %= 1'000'000'000;
+			timeout.tv_sec += 1;
+			timeout.tv_nsec -= 1'000'000'000;
 		}
 
 		if (futex_wait(&m_SharedState->m_Futex, expected, &timeout) < 0)
 		{
 			if (errno == EAGAIN)
 			{
-				// The value was not equal to the expected value, so we need to check the condition again.
+				// The value was not equal to the expected value. This usually means that
+				// the futex was triggered in between us getting the expected value and
+				// the futex_wait() call. So we need to reset the expected value and check
+				// the condition before calling futex_wait() again.
 				expected = m_SharedState->m_Futex.load(std::memory_order_acquire);
+				continue;
+			}
+
+			if (errno == ETIMEDOUT)
+			{
+				// The futex timed out. We should check the condition and futex_wait() again.
 				continue;
 			}
 

--- a/catkit_core/EventFutex.inl
+++ b/catkit_core/EventFutex.inl
@@ -50,6 +50,12 @@ inline void EventFutex::Wait(double timeout_in_sec, std::function<bool()> condit
 		timeout.tv_sec += static_cast<time_t>(timeout_wait);
 		timeout.tv_nsec += 1'000'000'000 * (timeout_wait - static_cast<time_t>(timeout_wait));
 
+		if (timeout.tv_nsec >= 1'000'000'000)
+		{
+			timeout.tv_sec += static_cast<time_t>(timeout.tv_nsec / 1'000'000'000);
+			timeout.tv_nsec %= 1'000'000'000;
+		}
+
 		if (futex_wait(&m_SharedState->m_Futex, expected, &timeout) < 0)
 		{
 			if (errno == EAGAIN)
@@ -60,7 +66,7 @@ inline void EventFutex::Wait(double timeout_in_sec, std::function<bool()> condit
 			}
 
 			// Otherwise, an error occurred.
-			throw std::runtime_error("Futex wait failed.");
+			throw std::runtime_error("Futex wait failed: " + std::to_string(errno));
 		}
 
 		if (error_check != nullptr)

--- a/catkit_core/EventFutex.inl
+++ b/catkit_core/EventFutex.inl
@@ -1,3 +1,78 @@
 #include "EventBase.h"
 
+#include <atomic>
+#include <chrono>
+#include <ctime>
+
+#ifdef __linux__
+#include <sys/syscall.h>
+#include <linux/futex.h>
+#endif // __linux__
+
 using EventFutex = EventImpl<EventImplementationType::Futex>;
+
+#ifdef __linux__
+
+template<>
+struct EventSharedState<EventImplementationType::Futex>
+{
+	std::atomic<int> m_Futex;
+};
+
+inline int futex_wait(std::atomic<int> *addr, int expected, const struct timespec* timeout)
+{
+	return syscall(SYS_futex, reinterpret_cast<int *>(addr), FUTEX_WAIT, expected, timeout, nullptr, 0);
+}
+
+inline int futex_wake(std::atomic<int> *addr, int count)
+{
+	return syscall(SYS_futex, reinterpret_cast<int *>(addr), FUTEX_WAKE, count, nullptr, nullptr, 0);
+}
+
+template<>
+inline void EventFutex::Wait(double timeout_in_sec, std::function<bool()> condition, void (*error_check)())
+{
+	Timer timer;
+	int expected = m_SharedState->m_Futex.load(std::memory_order_acquire);
+
+	while (!condition())
+	{
+		// Wait for a maximum of 20ms to perform periodic error checking.
+		double time_remaining = timeout_in_sec - timer.GetTime();
+		double timeout_wait = std::min(0.020, timeout_in_sec);
+
+		struct timespec timeout;
+		clock_gettime(CLOCK_MONOTONIC, &timeout);
+		timeout.tv_sec += static_cast<time_t>(timeout_wait);
+		timeout.tv_nsec += 1'000'000'000 * (timeout_wait - static_cast<time_t>(timeout_wait));
+
+		if (futex_wait(&m_SharedState->m_Futex, expected, &timeout) < 0)
+		{
+			if (errno == EAGAIN)
+			{
+				// The value was not equal to the expected value, so we need to check the condition again.
+				expected = m_SharedState->m_Futex.load(std::memory_order_acquire);
+				continue;
+			}
+
+			// Otherwise, an error occurred.
+			throw std::runtime_error("Futex wait failed.");
+		}
+
+		if (error_check != nullptr)
+			error_check();
+	}
+}
+
+template<>
+inline void EventFutex::Signal()
+{
+	m_SharedState->m_Futex.fetch_add(1, std::memory_order_release);
+
+	if (futex_wake(&m_SharedState->m_Futex, INT32_MAX) < 0)
+	{
+		throw std::runtime_error("Futex wake failed.");
+	}
+}
+
+#endif // __linux__

--- a/catkit_core/EventFutex.inl
+++ b/catkit_core/EventFutex.inl
@@ -48,12 +48,11 @@ inline void EventFutex::Wait(double timeout_in_sec, std::function<bool()> condit
 	{
 		// Wait for a maximum of 20ms to perform periodic error checking.
 		double time_remaining = timeout_in_sec - timer.GetTime();
-		double timeout_wait = std::min(0.020, timeout_in_sec);
+		double timeout_wait = std::min(0.020, time_remaining);
 
 		struct timespec timeout;
-		clock_gettime(CLOCK_MONOTONIC, &timeout);
-		timeout.tv_sec += static_cast<time_t>(timeout_wait);
-		timeout.tv_nsec += 1'000'000'000 * (timeout_wait - static_cast<time_t>(timeout_wait));
+		timeout.tv_sec = static_cast<time_t>(timeout_wait);
+		timeout.tv_nsec = 1'000'000'000 * (timeout_wait - static_cast<time_t>(timeout_wait));
 
 		if (timeout.tv_nsec >= 1'000'000'000)
 		{

--- a/catkit_core/EventFutex.inl
+++ b/catkit_core/EventFutex.inl
@@ -18,6 +18,11 @@ using EventFutex = EventImpl<EventImplementationType::Futex>;
 #ifdef __linux__
 
 template<>
+struct is_event_implemented<EventImplementationType::Futex> : std::true_type
+{
+};
+
+template<>
 struct EventSharedState<EventImplementationType::Futex>
 {
 	std::atomic<int> m_Futex;

--- a/catkit_core/EventFutex.inl
+++ b/catkit_core/EventFutex.inl
@@ -5,7 +5,11 @@
 #include <ctime>
 
 #ifdef __linux__
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif // _GNU_SOURCE
 #include <sys/syscall.h>
+#include <unistd.h>
 #include <linux/futex.h>
 #endif // __linux__
 

--- a/catkit_core/EventFutex.inl
+++ b/catkit_core/EventFutex.inl
@@ -79,4 +79,10 @@ inline void EventFutex::Signal()
 	}
 }
 
+template<>
+inline void EventFutex::CreateImpl(std::string_view id, SharedState *shared_state)
+{
+	shared_state->m_Futex = 0;
+}
+
 #endif // __linux__

--- a/catkit_core/EventSemaphore.inl
+++ b/catkit_core/EventSemaphore.inl
@@ -15,6 +15,11 @@ using EventSemaphore = EventImpl<EventImplementationType::Semaphore>;
 #ifdef _WIN32
 
 template<>
+struct is_event_implemented<EventImplementationType::Semaphore> : std::true_type
+{
+};
+
+template<>
 struct EventSharedState<EventImplementationType::Semaphore>
 {
 	std::atomic_long m_NumReadersWaiting;

--- a/catkit_core/EventSpinLock.inl
+++ b/catkit_core/EventSpinLock.inl
@@ -9,6 +9,11 @@ using EventSpinLock = EventImpl<EventImplementationType::SpinLock>;
 const std::size_t NUM_ITERATIONS_BETWEEN_CHECKS = 16;
 
 template<>
+struct is_event_implemented<EventImplementationType::SpinLock> : std::true_type
+{
+};
+
+template<>
 struct EventSharedState<EventImplementationType::SpinLock>
 {
 	std::atomic_size_t m_Counter;

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -36,9 +36,6 @@ def test_event(wait_method):
     waiting.wait(1)
     assert waiting.is_set(), 'Something went wrong starting the waiting thread.'
 
-    # Wait a bit before signaling.
-    time.sleep(0.01)
-
     # Ensure the event is not triggered unless signaled.
     with pytest.raises(RuntimeError):
         event.wait(lambda: condition[0] != 0, 0.1)

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -37,8 +37,13 @@ def test_event(wait_method):
     assert waiting.is_set(), 'Something went wrong starting the waiting thread.'
 
     # Ensure the event is not triggered unless signaled.
+    start = time.perf_counter()
     with pytest.raises(RuntimeError):
         event.wait(lambda: condition[0] != 0, 0.1)
+    end = time.perf_counter()
+
+    # Ensure that we at least waited for the timeout duration.
+    assert (end - start) >= 0.1
 
     # Signal the event.
     condition[0] = 1

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,5 +1,4 @@
-from catkit2.catkit_bindings import Event, LocalMemory
-import time
+from catkit2.catkit_bindings import Event, EventWaitMethod, LocalMemory, is_wait_method_implemented
 import threading
 import pytest
 
@@ -12,7 +11,16 @@ def event_wait(event, signal, waiting, condition):
 
     signal.set()
 
-def test_event():
+@pytest.mark.parametrize("wait_method", [
+    EventWaitMethod.Default,
+    EventWaitMethod.Semaphore,
+    EventWaitMethod.ConditionVariable,
+    EventWaitMethod.Futex,
+    EventWaitMethod.SpinLock])
+def test_event(wait_method):
+    if not is_wait_method_implemented(wait_method):
+        pytest.skip(f"Wait method {wait_method} is not implemented.")
+
     memory = LocalMemory.create(1024)
     event = Event.create(memory, 'test_event')
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,15 +1,14 @@
 from catkit2.catkit_bindings import Event, EventWaitMethod, LocalMemory, is_wait_method_implemented
 import threading
 import pytest
+import time
 
-def event_wait(event, signal, waiting, condition):
-    print(condition[0] != 0)
-
+def event_wait(event, signaled, waiting, condition):
     waiting.set()
 
     event.wait(lambda: condition[0] != 0, 2)
 
-    signal.set()
+    signaled.set()
 
 @pytest.mark.parametrize("wait_method", [
     EventWaitMethod.Default,
@@ -36,6 +35,9 @@ def test_event(wait_method):
     # Ensure that the waiting thread has started waiting.
     waiting.wait(1)
     assert waiting.is_set(), 'Something went wrong starting the waiting thread.'
+
+    # Wait a bit before signaling.
+    time.sleep(0.01)
 
     # Ensure the event is not triggered unless signaled.
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
> [!CAUTION]
> This PR requires #310 to be merged before.

Linux only. There might be a way to do MacOS too, but I remember there being issues with it not having a timeout. There is no way to do this type of synchronization accross processes in Windows, since it only supports intra-process futex.

This PR also adds a test for all (implemented) events, rather than just the default implementation.

Results on AMD Threadripper 5995WX (64 cores). This is the fastest (non-spinlock) synchronization primitive that is implemented on Linux by a full microsecond.
![image](https://github.com/user-attachments/assets/f0eb1b4e-3991-414a-ba83-e466142c4efb)
