### PR TITLE
Fix power setting in simulated NKT and MCLS1 Services 

### DIFF
--- a/catkit2/services/nkt_superk_sim/nkt_superk_sim.py
+++ b/catkit2/services/nkt_superk_sim/nkt_superk_sim.py
@@ -114,7 +114,7 @@ class NktSuperkSim(Service):
     def set_power_setpoint(self, power_setpoint):
         self.testbed.simulator.set_source_power(
             source_name=self.id,
-            power=self.emission.get()[0] * power_setpoint
+            power=self.emission.get()[0] * power_setpoint * 1e-2
         )
 
     def set_current_setpoint(self, current_setpoint):

--- a/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
+++ b/catkit2/services/thorlabs_mcls1_sim/thorlabs_mcls1_sim.py
@@ -83,7 +83,7 @@ class ThorlabsMcls1Sim(Service):
     def set_emission(self, emission):
         self.testbed.simulator.set_source_power(
             source_name=self.id,
-            power=emission * self.power_setpoint.get()[0] * 1e-2
+            power=emission * self.power_setpoint.get()[0]
         )
 
     def set_power_setpoint(self, power_setpoint):


### PR DESCRIPTION
For the NKT,  the `power` (and `power_setpoint`) is given as a percentage of the total power provided by the input spectrum which is defined under `spectrum_fname` in the `simulator.yml`. The power should therefore be multiplied by 1e-2 in the `set_emission` and `set_power_setpoint` functions to reflect the percentage. 

For the MCLS1, however, the `power` is just the total power in the wavefront and should not be multiplied by the 1e-2 factor. 

Something that is still unclear me though is why in the simulated services the `power_setpoint` from the `services.yml` are used to set the power in the `set_emission` and `set_power_setpoint` functions. Typically on hardware we work with currents and so I'm not even sure if the `power` from the `simulator.yml` and the `power_setpoint` from the `services.yml` are referring to the same thing here.  