### PR TITLE
Cleanup callbacks and properties after a `Server` or `Service` stops.

### DIFF
--- a/catkit2/__init__.py
+++ b/catkit2/__init__.py
@@ -1,8 +1,12 @@
 # flake8: noqa
 
+# Setting to ensure CTRL-C commands are caught, which allows services to exit properly.
 import os
+os.environ['FOR_DISABLE_CONSOLE_CTRL_HANDLER'] = '1'
 
+# Enable printing of stacktrace upon segfault.
 import faulthandler
+faulthandler.enable()
 
 from . import testbed
 from . import simulator
@@ -18,9 +22,3 @@ __version__ = get_version()
 __all__ = []
 __all__.extend(testbed.__all__)
 __all__.extend(simulator.__all__)
-
-# Setting to ensure CTRL-C commands are caught, which allows services to exit properly.
-os.environ['FOR_DISABLE_CONSOLE_CTRL_HANDLER'] = '1'
-
-# Enable printing of stacktrace upon segfault.
-faulthandler.enable()

--- a/catkit2/bindings.cpp
+++ b/catkit2/bindings.cpp
@@ -530,7 +530,8 @@ PYBIND11_MODULE(catkit_bindings, m)
 		.def("sleep", [](Server &server, double sleep_time_in_sec)
 		{
 			server.Sleep(sleep_time_in_sec, error_check_python);
-		}, py::call_guard<py::gil_scoped_release>());
+		}, py::call_guard<py::gil_scoped_release>())
+		.def("cleanup_request_handlers", &Server::CleanupRequestHandlers);
 
 	py::class_<Client>(m, "Client")
 		.def(py::init<std::string, int>())
@@ -606,7 +607,8 @@ PYBIND11_MODULE(catkit_bindings, m)
 			DataType dtype = GetDataTypeFromString(type);
 			return service.MakeDataStream(stream_name, dtype, dimensions, num_frames_in_buffer);
 		})
-		.def("reuse_data_stream", &Service::ReuseDataStream);
+		.def("reuse_data_stream", &Service::ReuseDataStream)
+		.def("cleanup_attributes", &Service::CleanupAttributes);
 
 	py::enum_<ServiceState>(m, "ServiceState")
 		.value("CLOSED", ServiceState::CLOSED)

--- a/catkit_core/Server.cpp
+++ b/catkit_core/Server.cpp
@@ -36,7 +36,9 @@ void Server::Start()
     if (IsRunning())
         throw runtime_error("This server is already running.");
 
-	m_ShouldShutDown = false;
+	if (m_ShouldShutDown)
+		throw runtime_error("This server can only run once.");
+
 	m_IsRunning = true;
 
     m_RunThread = thread(&Server::RunInternal, this);
@@ -48,6 +50,13 @@ void Server::Stop()
 
 	if (m_RunThread.joinable())
 		m_RunThread.join();
+
+	CleanupRequestHandlers();
+}
+
+void Server::CleanupRequestHandlers()
+{
+	m_RequestHandlers.clear();
 }
 
 void Server::RunInternal()

--- a/catkit_core/Server.h
+++ b/catkit_core/Server.h
@@ -26,6 +26,8 @@ public:
 
 	void Sleep(double sleep_time_in_sec, void (*error_check)()=nullptr);
 
+	void CleanupRequestHandlers();
+
 protected:
 	int m_Port;
 

--- a/catkit_core/Service.cpp
+++ b/catkit_core/Service.cpp
@@ -68,6 +68,12 @@ Service::~Service()
 
 void Service::Run(void (*error_check)())
 {
+	if (m_ShouldShutDown)
+		throw std::runtime_error("A service can only run once.");
+
+	if (m_IsRunning)
+		throw std::runtime_error("The service is already running.");
+
 	// Perform check on requires safety property in config.
 	if (!m_Config.contains("requires_safety"))
 	{
@@ -204,6 +210,15 @@ void Service::Run(void (*error_check)())
 	// Set heartbeat timestamp to zero to signal a dead service.
 	std::uint64_t timestamp = 0;
 	m_Heartbeat->SubmitData(&timestamp);
+
+	CleanupAttributes();
+}
+
+void Service::CleanupAttributes()
+{
+	m_Properties.clear();
+	m_Commands.clear();
+	m_DataStreams.clear();
 }
 
 void Service::MonitorSafety()

--- a/catkit_core/Service.h
+++ b/catkit_core/Service.h
@@ -53,6 +53,8 @@ public:
 
 	std::shared_ptr<TestbedProxy> GetTestbed();
 
+	void CleanupAttributes();
+
 private:
 	std::string HandleGetInfo(const std::string &data);
 
@@ -87,9 +89,6 @@ private:
 	std::shared_ptr<DataStream> m_Heartbeat;
 	std::shared_ptr<DataStream> m_Safety;
 	std::shared_ptr<DataStream> m_State;
-
-	typedef std::function<std::string(const std::string &)> MessageHandler;
-	std::map<std::string, MessageHandler> m_RequestHandlers;
 
 	std::map<std::string, std::shared_ptr<Property>> m_Properties;
 	std::map<std::string, std::shared_ptr<Command>> m_Commands;

--- a/tests/test_server_client.py
+++ b/tests/test_server_client.py
@@ -1,8 +1,7 @@
 from catkit2.catkit_bindings import Server, Client
-import threading
 import time
 import pytest
-import socket
+import weakref
 
 class OurServer(Server):
     def __init__(self, port):
@@ -47,3 +46,37 @@ def test_server_client_communication(unused_port):
         client.baz()
 
     server.stop()
+
+def test_server_cleanup(unused_port):
+    port = unused_port()
+    server = OurServer(port)
+
+    # Use a weak reference to the server, to check if actually gets deleted.
+    server_ref = weakref.ref(server)
+    assert server_ref() is not None
+
+    # Run the server.
+    server.start()
+    time.sleep(0.5)
+    server.stop()
+
+    # Delete the server.
+    del server
+
+    # The server should now have been deleted.
+    assert server_ref() is None
+
+def test_server_cleanup_manual(unused_port):
+    port = unused_port()
+    server = OurServer(port)
+
+    # Use a weak reference to the server, to check if actually gets deleted.
+    server_ref = weakref.ref(server)
+    assert server_ref() is not None
+
+    # Cleanup the request handlers and delete the server.
+    server.cleanup_request_handlers()
+    del server
+
+    # This should have deleted the server object itself.
+    assert server_ref() is None


### PR DESCRIPTION
Fixes #321.