### PR TITLE
Add a stage model for motors with different specifications

### DIFF
--- a/catkit2/services/thorlabs_cube_motor_kinesis/thorlabs_cube_motor_kinesis.py
+++ b/catkit2/services/thorlabs_cube_motor_kinesis/thorlabs_cube_motor_kinesis.py
@@ -108,6 +108,10 @@ class ThorlabsCubeMotorKinesis(Service):
             steps_per_rev = c_double(512)
             gear_box_ratio = c_double(67.49)
             pitch_mm = c_double(1.0)
+        elif self.stage_model == 'MTS25':
+            steps_per_rev = c_double(48)
+            gear_box_ratio = c_double(256)
+            pitch_mm = c_double(0.5)
         else:
             raise ValueError(f"Stage model {self.stage_model} not supported.")
 

--- a/catkit2/services/thorlabs_cube_motor_kinesis/thorlabs_cube_motor_kinesis.py
+++ b/catkit2/services/thorlabs_cube_motor_kinesis/thorlabs_cube_motor_kinesis.py
@@ -103,7 +103,7 @@ class ThorlabsCubeMotorKinesis(Service):
         self.lib.CC_Open(self.serial_number)
         self.lib.CC_StartPolling(self.serial_number, c_int(200))
 
-        if self.stage_model in ['MTS25-Z8', 'MTS50-Z8', 'Z825B', 'Z806', 'Z812']:
+        if 'Z8' in self.stage_model:
             # Set up the device to convert real units to device units
             steps_per_rev = c_double(512)
             gear_box_ratio = c_double(67.49)

--- a/catkit2/services/thorlabs_cube_motor_kinesis/thorlabs_cube_motor_kinesis.py
+++ b/catkit2/services/thorlabs_cube_motor_kinesis/thorlabs_cube_motor_kinesis.py
@@ -106,7 +106,7 @@ class ThorlabsCubeMotorKinesis(Service):
         if 'Z8' in self.stage_model:
             # Set up the device to convert real units to device units
             steps_per_rev = c_double(512)
-            gear_box_ratio = c_double(67.49)
+            gear_box_ratio = c_double(67.0)
             pitch_mm = c_double(1.0)
         elif self.stage_model == 'MTS25':
             steps_per_rev = c_double(48)


### PR DESCRIPTION
See https://github.com/ivalaginja/thd-controls/issues/376.
Linked with https://github.com/ivalaginja/thd-controls/pull/387

Added the stage model 'MTS25' with different pitch, gear ratio and step per rev than the several Z8 motors.
Manual for this motor :
https://www.thorlabs.com/thorproduct.cfm?partnumber=MTS25X&pn=MTS25X

The Z8 motors all have the same gear ratio, head and step per rev (see manual page 2 and 3 https://www.thorlabs.com/thorproduct.cfm?partnumber=MTS25-Z8) so any stage with Z8 motor should have these spectifications.

Still need to be tested on hw.