### PR TITLE
updating the VCP port

### DIFF
--- a/catkit2/services/thorlabs_mcls1/thorlabs_mcls1.py
+++ b/catkit2/services/thorlabs_mcls1/thorlabs_mcls1.py
@@ -131,12 +131,12 @@ class ThorlabsMcls1(Service):
             # Last time this happened we identified the COM port in the device manager by unplugging / replugging
             # and then figuring the corresponding VCP port from the above debugging message.
 
-            if 'VCP11' in thing:
+            if 'VCP0' in thing:
                 self.port = split[i - 1]
                 print(f'port number from thing ={self.port}')
                 break
         else:
-            raise Exception('Device VCP11 not found')
+            raise Exception('Device VCP0 not found - The MCLS1 probably switched port after a reboot')
 
         self.instrument_handle = self.UART_lib.fnUART_LIBRARY_open(self.port.encode(), MCLS1_COM.BAUD_RATE.value, 3)
 


### PR DESCRIPTION
The VCP port of the MCLS1 keeps changing by itself after rebooting, so this PR updates it to be consistent with the current hardware state. 

This needs to be fixed properly later because this is a HiCAT hardware dependency. 

We still need to get back to #304 to solve this properly