### PR TITLE
Hack for BMMC DMs on HiCAT with PCIe device setting 

### DIFF
--- a/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
+++ b/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
@@ -31,11 +31,11 @@ class BmcDeformableMirrorHardware(BmcDeformableMirror):
 
         pcie_status = self.device.set_device_id(self.device_id)
         if pcie_status != bmc.NO_ERR:
-            raise RuntimeError(f'Failed to connect: {self.dm.error_string(pcie_status)}.')
+            raise RuntimeError(f'Failed to connect: {self.device.error_string(pcie_status)}.')
 
         dm_status = self.device.open_dm(self.serial_number)
         if dm_status != bmc.NO_ERR:
-            raise RuntimeError(f'Failed to connect: {self.dm.error_string(dm_status)}.')
+            raise RuntimeError(f'Failed to connect: {self.device.error_string(dm_status)}.')
 
         self.device.enable_high_res(enable=self.enable_high_resolution)
         self.device_command_length = self.device.num_actuators()

--- a/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
+++ b/catkit2/services/bmc_deformable_mirror_hardware/bmc_deformable_mirror_hardware.py
@@ -29,9 +29,10 @@ class BmcDeformableMirrorHardware(BmcDeformableMirror):
     def open(self):
         self.device = bmc.BmcDm()
 
-        pcie_status = self.device.set_device_id(self.device_id)
-        if pcie_status != bmc.NO_ERR:
-            raise RuntimeError(f'Failed to connect: {self.device.error_string(pcie_status)}.')
+        if self.device_id:
+            pcie_status = self.device.set_device_id(self.device_id)
+            if pcie_status != bmc.NO_ERR:
+                raise RuntimeError(f'Failed to connect: {self.device.error_string(pcie_status)}.')
 
         dm_status = self.device.open_dm(self.serial_number)
         if dm_status != bmc.NO_ERR:


### PR DESCRIPTION
Partially addresses #327. 

This is a hack to allow the DMs to work on HiCAT after the DM refactor. Another future PR will need to address the underlying issue of why the `set_device_id` function is not handling being passed 0 in the expected way.  

- [x] Tested on HiCAT hardware  

@ivalaginja would appreciate your input/testing to make sure this doesn't impact anything with THD2