### PR TITLE
C++ deformable mirror base class

### DIFF
--- a/catkit_core/DeformableMirrorService.cpp
+++ b/catkit_core/DeformableMirrorService.cpp
@@ -1,0 +1,134 @@
+#include "DeformableMirrorService.h"
+
+#include "FitsFile.h"
+
+template<typename T>
+void CastToBool(T *data, bool *mask, size_t size)
+{
+	for (size_t i = 0; i < size; ++i)
+		mask[i] = data[i] > 0;
+}
+
+template<typename T>
+void CastToDouble(T *data, double *mask, size_t size)
+{
+	for (size_t i = 0; i < size; ++i)
+		mask[i] = data[i];
+}
+
+DeformableMirrorService::DeformableMirrorService(std::string service_type, std::string service_id, int service_port, int testbed_port)
+	: Service(service_type, service_id, service_port, testbed_port)
+{
+	// Get the actuator mask.
+	auto config = GetConfig();
+
+	if (!config.contains("device_actuator_mask_fname"))
+		throw std::runtime_error("Need to provide a device actuator mask for the deformable mirror.");
+
+	std::string device_actuator_mask_fname = config["device_actuator_mask_fname"].get<std::string>();
+	FitsFile actuator_mask_fits = FitsFile(device_actuator_mask_fname);
+
+	m_ActuatorMask = actuator_mask_fits.GetDataCasted<bool>();
+	m_Shape = actuator_mask_fits.GetShape();
+
+	// Get the number of actuators.
+	m_NumActuators = 0;
+	for (auto mask : m_ActuatorMask)
+	{
+		if (mask)
+			++m_NumActuators;
+	}
+
+	// Allocate current surface.
+	m_CurrentSurface = new double[m_NumActuators];
+
+	// Get channel ids from config.
+	for (auto channel_id : config["channel_ids"])
+		m_ChannelIds.push_back(channel_id);
+
+	// Create data stream for each channel.
+	for (auto channel_id : m_ChannelIds)
+	{
+		m_ChannelStreams[channel_id] = DataStream::Create(channel_id, GetId(), DataType::DT_FLOAT64, {m_NumActuators}, 20);
+	}
+}
+
+DeformableMirrorService::~DeformableMirrorService()
+{
+	delete[] m_CurrentSurface;
+}
+
+void DeformableMirrorService::Start()
+{
+	// Start monitoring channels.
+	for (auto channel_id : m_ChannelIds)
+	{
+		m_ChannelThreads[channel_id] = std::thread(&DeformableMirrorService::MonitorChannel, this, channel_id);
+	}
+}
+
+void DeformableMirrorService::Main()
+{
+	while (!ShouldShutDown())
+	{
+		Sleep(1);
+	}
+}
+
+void DeformableMirrorService::Stop()
+{
+	for (auto &thread : m_ChannelThreads)
+		thread.second.join();
+}
+
+void DeformableMirrorService::MonitorChannel(std::string channel_id)
+{
+	// Initialize the empty surface.
+	double *prev_surface = new double[m_NumActuators];
+	for (size_t i = 0; i < m_NumActuators; ++i)
+		prev_surface[i] = 0;
+
+	double *diff_surface = new double[m_NumActuators];
+
+	std::shared_ptr<DataStream> stream = m_ChannelStreams[channel_id];
+
+	while (!ShouldShutDown())
+	{
+		// Wait for the next frame.
+		DataFrame frame;
+
+		try
+		{
+			frame = stream->GetNextFrame(0.01);
+		}
+		catch (const std::exception &e)
+		{
+			continue;
+		}
+
+		// Compute the differential surface.
+		double *new_surface = (double *)frame.GetData();
+
+		for (size_t i = 0; i < m_NumActuators; ++i)
+			diff_surface[i] = new_surface[i] - prev_surface[i];
+
+		// Apply the surface delta to the current surface.
+		ApplySurfaceDelta(diff_surface);
+
+		// Update the previous surface.
+		for (size_t i = 0; i < m_NumActuators; ++i)
+			prev_surface[i] = new_surface[i];
+	}
+}
+
+void DeformableMirrorService::ApplySurfaceDelta(double *surface_delta)
+{
+	std::lock_guard<std::mutex> lock(m_Mutex);
+
+	// Apply the surface delta to the current surface.
+	for (std::size_t i = 0; i < m_NumActuators; ++i)
+		m_CurrentSurface[i] += surface_delta[i];
+
+	// Apply the current surface to the deformable mirror.
+	ApplySurface(m_CurrentSurface);
+}

--- a/catkit_core/DeformableMirrorService.cpp
+++ b/catkit_core/DeformableMirrorService.cpp
@@ -50,6 +50,15 @@ DeformableMirrorService::DeformableMirrorService(std::string service_type, std::
 	for (auto channel_id : m_ChannelIds)
 	{
 		m_ChannelStreams[channel_id] = DataStream::Create(channel_id, GetId(), DataType::DT_FLOAT64, {m_NumActuators}, 20);
+
+		// Read in the initial map.
+		if (config["startup_maps"].contains(channel_id))
+		{
+			FitsFile startup_map_file = FitsFile(config["startup_maps"][channel_id]);
+			std::vector<double> startup_map = startup_map_file.GetDataCasted<double>();
+
+			m_ChannelStreams[channel_id]->SubmitData(startup_map.data());
+		}
 	}
 }
 

--- a/catkit_core/DeformableMirrorService.cpp
+++ b/catkit_core/DeformableMirrorService.cpp
@@ -60,6 +60,16 @@ DeformableMirrorService::DeformableMirrorService(std::string service_type, std::
 			m_ChannelStreams[channel_id]->SubmitData(startup_map.data());
 		}
 	}
+
+	// Create total surface data stream.
+	m_TotalSurface = DataStream::Create("total_surface", GetId(), DataType::DT_FLOAT64, {m_NumActuators}, 20);
+
+	// Create channels property.
+	List channels;
+	for (auto channel_id : m_ChannelIds)
+		channels.push_back(Value(channel_id));
+
+	MakeProperty("channels", [channels]() { return channels; });
 }
 
 DeformableMirrorService::~DeformableMirrorService()
@@ -140,4 +150,6 @@ void DeformableMirrorService::ApplySurfaceDelta(double *surface_delta)
 
 	// Apply the current surface to the deformable mirror.
 	ApplySurface(m_CurrentSurface);
+
+	m_TotalSurface->SubmitData(m_CurrentSurface);
 }

--- a/catkit_core/DeformableMirrorService.h
+++ b/catkit_core/DeformableMirrorService.h
@@ -35,6 +35,8 @@ private:
 	std::vector<std::string> m_ChannelIds;
 	std::map<std::string, std::thread> m_ChannelThreads;
 	std::map<std::string, std::shared_ptr<DataStream>> m_ChannelStreams;
+
+	std::shared_ptr<DataStream> m_TotalSurface;
 };
 
 #endif // DEFORMABLE_MIRROR_SERVICE_H

--- a/catkit_core/DeformableMirrorService.h
+++ b/catkit_core/DeformableMirrorService.h
@@ -1,0 +1,40 @@
+#ifndef DEFORMABLE_MIRROR_SERVICE_H
+#define DEFORMABLE_MIRROR_SERVICE_H
+
+#include "Service.h"
+
+#include <thread>
+#include <mutex>
+#include <vector>
+#include <map>
+
+class DeformableMirrorService : public Service
+{
+public:
+	DeformableMirrorService(std::string service_type, std::string service_id, int service_port, int testbed_port);
+	virtual ~DeformableMirrorService();
+
+	virtual void Start();
+	virtual void Main();
+	virtual void Stop();
+
+	virtual void ApplySurface(double *surface) = 0;
+
+private:
+	void MonitorChannel(std::string channel_id);
+	void ApplySurfaceDelta(double *surface_delta);
+
+	std::mutex m_Mutex;
+	double *m_CurrentSurface;
+
+	std::vector<bool> m_ActuatorMask;
+	std::vector<long> m_Shape;
+
+	std::size_t m_NumActuators;
+
+	std::vector<std::string> m_ChannelIds;
+	std::map<std::string, std::thread> m_ChannelThreads;
+	std::map<std::string, std::shared_ptr<DataStream>> m_ChannelStreams;
+};
+
+#endif // DEFORMABLE_MIRROR_SERVICE_H

--- a/catkit_core/FitsFile.cpp
+++ b/catkit_core/FitsFile.cpp
@@ -4,7 +4,7 @@
 
 FitsFile::FitsFile(std::string fname, std::string hdu_name)
 {
-	int status;
+	int status = 0;
 
 	if (fits_open_file(&m_File, fname.c_str(), READONLY, &status))
 	{
@@ -22,13 +22,13 @@ FitsFile::FitsFile(std::string fname, std::string hdu_name)
 
 FitsFile::~FitsFile()
 {
-	int status;
+	int status = 0;
 	fits_close_file(m_File, &status);
 }
 
 int FitsFile::GetNDim()
 {
-	int status;
+	int status = 0;
 	int naxis;
 	if (fits_get_img_dim(m_File, &naxis, &status))
 	{
@@ -41,7 +41,7 @@ int FitsFile::GetNDim()
 
 std::vector<long> FitsFile::GetShape()
 {
-	int status;
+	int status = 0;
 
 	std::vector<long> shape;
 	shape.resize(GetNDim());
@@ -66,8 +66,9 @@ long FitsFile::GetSize()
 
 int FitsFile::GetDataType()
 {
-	int status;
+	int status = 0;
 	int bitpix;
+
 	if (fits_get_img_type(m_File, &bitpix, &status))
 	{
 		fits_report_error(stderr, status);

--- a/catkit_core/FitsFile.cpp
+++ b/catkit_core/FitsFile.cpp
@@ -1,0 +1,90 @@
+#include "FitsFile.h"
+
+#include <stdexcept>
+
+FitsFile::FitsFile(std::string fname, std::string hdu_name)
+{
+	int status;
+
+	if (fits_open_file(&m_File, fname.c_str(), READONLY, &status))
+	{
+		fits_report_error(stderr, status);
+		throw std::runtime_error("Failed to open FITS file.");
+	}
+
+	if (fits_movnam_hdu(m_File, IMAGE_HDU, const_cast<char *>(hdu_name.c_str()), 0, &status))
+	{
+		fits_report_error(stderr, status);
+		fits_close_file(m_File, &status);
+		throw std::runtime_error("Failed to move to HDU.");
+	}
+}
+
+FitsFile::~FitsFile()
+{
+	int status;
+	fits_close_file(m_File, &status);
+}
+
+int FitsFile::GetNDim()
+{
+	int status;
+	int naxis;
+	if (fits_get_img_dim(m_File, &naxis, &status))
+	{
+		fits_report_error(stderr, status);
+		throw std::runtime_error("Failed to get image dimension.");
+	}
+
+	return naxis;
+}
+
+std::vector<long> FitsFile::GetShape()
+{
+	int status;
+
+	std::vector<long> shape;
+	shape.resize(GetNDim());
+
+	if (fits_get_img_size(m_File, shape.size(), shape.data(), &status))
+	{
+		fits_report_error(stderr, status);
+		throw std::runtime_error("Failed to get image shape.");
+	}
+
+	return shape;
+}
+
+long FitsFile::GetSize()
+{
+	long size = 1;
+	for (auto s : GetShape())
+		size *= s;
+
+	return size;
+}
+
+int FitsFile::GetDataType()
+{
+	int status;
+	int bitpix;
+	if (fits_get_img_type(m_File, &bitpix, &status))
+	{
+		fits_report_error(stderr, status);
+		throw std::runtime_error("Failed to get image type.");
+	}
+
+	return bitpix;
+}
+
+std::string FitsFile::GetFitsError()
+{
+	std::string error;
+	char error_message[80];
+
+	while (fits_read_errmsg(error_message))
+		error += error_message;
+		error += "\n";
+
+	return error;
+}

--- a/catkit_core/FitsFile.h
+++ b/catkit_core/FitsFile.h
@@ -1,0 +1,34 @@
+#ifndef FITS_FILE_H
+#define FITS_FILE_H
+
+#include <string>
+#include <vector>
+#include <utility>
+#include <fitsio.h>
+
+class FitsFile
+{
+public:
+	FitsFile(std::string fname, std::string hdu_name = "");
+	~FitsFile();
+
+	int GetNDim();
+	std::vector<long> GetShape();
+	long GetSize();
+	int GetDataType();
+
+    template <typename T>
+	std::vector<T> GetData();
+
+	template <typename T>
+	std::vector<T> GetDataCasted();
+
+private:
+	std::string GetFitsError();
+
+	fitsfile *m_File;
+};
+
+#include "FitsFile.inl"
+
+#endif // FITS_FILE_H

--- a/catkit_core/FitsFile.inl
+++ b/catkit_core/FitsFile.inl
@@ -70,8 +70,9 @@ struct type_to_bitpix<double>
 template<typename T>
 std::vector<T> FitsFile::GetData()
 {
-	int status;
+	int status = 0;
 	int anynulls;
+
 	std::vector<T> data;
 	data.resize(GetSize());
 
@@ -91,7 +92,8 @@ std::vector<T> FitsFile::GetData()
 template<typename T>
 std::vector<T> FitsFile::GetDataCasted()
 {
-	int status;
+	int status = 0;
+
 	std::vector<T> data;
 	data.resize(GetSize());
 

--- a/catkit_core/FitsFile.inl
+++ b/catkit_core/FitsFile.inl
@@ -71,6 +71,7 @@ template<typename T>
 std::vector<T> FitsFile::GetData()
 {
 	int status;
+	int anynulls;
 	std::vector<T> data;
 	data.resize(GetSize());
 
@@ -78,7 +79,7 @@ std::vector<T> FitsFile::GetData()
 	if (GetDataType() != type_to_bitpix<T>::value)
 		throw std::runtime_error("Data type mismatch.");
 
-	if (fits_read_img(m_File, , 1, data.size(), NULL, data.data(), &status))
+	if (fits_read_img(m_File, GetDataType(), 1, data.size(), NULL, data.data(), &anynulls, &status))
 	{
 		fits_report_error(stderr, status);
 		throw std::runtime_error("Failed to read image.");
@@ -94,57 +95,69 @@ std::vector<T> FitsFile::GetDataCasted()
 	std::vector<T> data;
 	data.resize(GetSize());
 
+	// Define all possible data types.
+	std::vector<uint8_t> byte_data;
+	std::vector<int8_t> sbyte_data;
+	std::vector<int16_t> short_data;
+	std::vector<uint16_t> ushort_data;
+	std::vector<int32_t> int_data;
+	std::vector<uint32_t> uint_data;
+	std::vector<int64_t> long_data;
+	std::vector<uint64_t> ulong_data;
+	std::vector<float> float_data;
+	std::vector<double> double_data;
+
 	switch (GetDataType())
 	{
 	case TBYTE:
-		auto original_data = GetData<uint8_t>();
-		for (size_t i = 0; i < original_data.size(); ++i)
-			data[i] = static_cast<T>(original_data[i]);
+		byte_data = GetData<uint8_t>();
+		for (size_t i = 0; i < byte_data.size(); ++i)
+			data[i] = static_cast<T>(byte_data[i]);
 		break;
 	case TSBYTE:
-		auto original_data = GetData<int8_t>();
-		for (size_t i = 0; i < original_data.size(); ++i)
-			data[i] = static_cast<T>(original_data[i]);
+		sbyte_data = GetData<int8_t>();
+		for (size_t i = 0; i < sbyte_data.size(); ++i)
+			data[i] = static_cast<T>(sbyte_data[i]);
 		break;
 	case TSHORT:
-		auto original_data = GetData<int16_t>();
-		for (size_t i = 0; i < original_data.size(); ++i)
-			data[i] = static_cast<T>(original_data[i]);
+		short_data = GetData<int16_t>();
+		for (size_t i = 0; i < short_data.size(); ++i)
+			data[i] = static_cast<T>(short_data[i]);
 		break;
 	case TUSHORT:
-		auto original_data = GetData<uint16_t>();
-		for (size_t i = 0; i < original_data.size(); ++i)
-			data[i] = static_cast<T>(original_data[i]);
+		ushort_data = GetData<uint16_t>();
+		for (size_t i = 0; i < ushort_data.size(); ++i)
+			data[i] = static_cast<T>(ushort_data[i]);
 		break;
 	case TLONG:
-		auto original_data = GetData<int64_t>();
-		for (size_t i = 0; i < original_data.size(); ++i)
-			data[i] = static_cast<T>(original_data[i]);
+		long_data = GetData<int64_t>();
+		for (size_t i = 0; i < long_data.size(); ++i)
+			data[i] = static_cast<T>(long_data[i]);
 		break;
 	case TULONG:
-		auto original_data = GetData<uint64_t>();
-		for (size_t i = 0; i < original_data.size(); ++i)
-			data[i] = static_cast<T>(original_data[i]);
+		ulong_data = GetData<uint64_t>();
+		for (size_t i = 0; i < ulong_data.size(); ++i)
+			data[i] = static_cast<T>(ulong_data[i]);
 		break;
 	case TINT:
-		auto original_data = GetData<int32_t>();
-		for (size_t i = 0; i < original_data.size(); ++i)
-			data[i] = static_cast<T>(original_data[i]);
+		int_data = GetData<int32_t>();
+		for (size_t i = 0; i < int_data.size(); ++i)
+			data[i] = static_cast<T>(int_data[i]);
 		break;
 	case TUINT:
-		auto original_data = GetData<uint32_t>();
-		for (size_t i = 0; i < original_data.size(); ++i)
-			data[i] = static_cast<T>(original_data[i]);
+		uint_data = GetData<uint32_t>();
+		for (size_t i = 0; i < uint_data.size(); ++i)
+			data[i] = static_cast<T>(uint_data[i]);
 		break;
 	case TFLOAT:
-		auto original_data = GetData<float>();
-		for (size_t i = 0; i < original_data.size(); ++i)
-			data[i] = static_cast<T>(original_data[i]);
+		float_data = GetData<float>();
+		for (size_t i = 0; i < float_data.size(); ++i)
+			data[i] = static_cast<T>(float_data[i]);
 		break;
 	case TDOUBLE:
-		auto original_data = GetData<double>();
-		for (size_t i = 0; i < original_data.size(); ++i)
-			data[i] = static_cast<T>(original_data[i]);
+		double_data = GetData<double>();
+		for (size_t i = 0; i < double_data.size(); ++i)
+			data[i] = static_cast<T>(double_data[i]);
 		break;
 	default:
 		throw std::runtime_error("Unsupported data type");

--- a/catkit_core/FitsFile.inl
+++ b/catkit_core/FitsFile.inl
@@ -1,0 +1,154 @@
+#include "FitsFile.h"
+
+#include <stdexcept>
+
+template<typename T>
+struct type_to_bitpix
+{
+};
+
+template<>
+struct type_to_bitpix<std::uint8_t>
+{
+	static const int value = TBYTE;
+};
+
+template<>
+struct type_to_bitpix<std::int8_t>
+{
+	static const int value = TSBYTE;
+};
+
+template<>
+struct type_to_bitpix<std::int16_t>
+{
+	static const int value = TSHORT;
+};
+
+template<>
+struct type_to_bitpix<std::uint16_t>
+{
+	static const int value = TUSHORT;
+};
+
+template<>
+struct type_to_bitpix<std::int32_t>
+{
+	static const int value = TINT;
+};
+
+template<>
+struct type_to_bitpix<std::uint32_t>
+{
+	static const int value = TUINT;
+};
+
+template<>
+struct type_to_bitpix<std::int64_t>
+{
+	static const int value = TLONG;
+};
+
+template<>
+struct type_to_bitpix<std::uint64_t>
+{
+	static const int value = TULONG;
+};
+
+template<>
+struct type_to_bitpix<float>
+{
+	static const int value = TFLOAT;
+};
+
+template<>
+struct type_to_bitpix<double>
+{
+	static const int value = TDOUBLE;
+};
+
+template<typename T>
+std::vector<T> FitsFile::GetData()
+{
+	int status;
+	std::vector<T> data;
+	data.resize(GetSize());
+
+	// Check data type.
+	if (GetDataType() != type_to_bitpix<T>::value)
+		throw std::runtime_error("Data type mismatch.");
+
+	if (fits_read_img(m_File, , 1, data.size(), NULL, data.data(), &status))
+	{
+		fits_report_error(stderr, status);
+		throw std::runtime_error("Failed to read image.");
+	}
+
+	return std::move(data);
+}
+
+template<typename T>
+std::vector<T> FitsFile::GetDataCasted()
+{
+	int status;
+	std::vector<T> data;
+	data.resize(GetSize());
+
+	switch (GetDataType())
+	{
+	case TBYTE:
+		auto original_data = GetData<uint8_t>();
+		for (size_t i = 0; i < original_data.size(); ++i)
+			data[i] = static_cast<T>(original_data[i]);
+		break;
+	case TSBYTE:
+		auto original_data = GetData<int8_t>();
+		for (size_t i = 0; i < original_data.size(); ++i)
+			data[i] = static_cast<T>(original_data[i]);
+		break;
+	case TSHORT:
+		auto original_data = GetData<int16_t>();
+		for (size_t i = 0; i < original_data.size(); ++i)
+			data[i] = static_cast<T>(original_data[i]);
+		break;
+	case TUSHORT:
+		auto original_data = GetData<uint16_t>();
+		for (size_t i = 0; i < original_data.size(); ++i)
+			data[i] = static_cast<T>(original_data[i]);
+		break;
+	case TLONG:
+		auto original_data = GetData<int64_t>();
+		for (size_t i = 0; i < original_data.size(); ++i)
+			data[i] = static_cast<T>(original_data[i]);
+		break;
+	case TULONG:
+		auto original_data = GetData<uint64_t>();
+		for (size_t i = 0; i < original_data.size(); ++i)
+			data[i] = static_cast<T>(original_data[i]);
+		break;
+	case TINT:
+		auto original_data = GetData<int32_t>();
+		for (size_t i = 0; i < original_data.size(); ++i)
+			data[i] = static_cast<T>(original_data[i]);
+		break;
+	case TUINT:
+		auto original_data = GetData<uint32_t>();
+		for (size_t i = 0; i < original_data.size(); ++i)
+			data[i] = static_cast<T>(original_data[i]);
+		break;
+	case TFLOAT:
+		auto original_data = GetData<float>();
+		for (size_t i = 0; i < original_data.size(); ++i)
+			data[i] = static_cast<T>(original_data[i]);
+		break;
+	case TDOUBLE:
+		auto original_data = GetData<double>();
+		for (size_t i = 0; i < original_data.size(); ++i)
+			data[i] = static_cast<T>(original_data[i]);
+		break;
+	default:
+		throw std::runtime_error("Unsupported data type");
+	}
+
+	return std::move(data);
+}

--- a/environment.yml
+++ b/environment.yml
@@ -32,6 +32,7 @@ dependencies:
   - conda-forge::eigen==3.4.0
   - conda-forge::nlohmann_json==3.9.1
   - conda-forge::pybind11_json
+  - conda-forge::cfitsio
   - pip
   - cmake>=3.0.0
   - doxygen


### PR DESCRIPTION
Work in progress. Todo:

- [x] Add startup maps.
- [x] Adding and updating data streams.
- [x] Add properties.
- [ ] other things?

This PR adds a C++ base class for deformable mirrors. This allows us to perform multiple channel updates asynchronously and independently, unlike the current Python base class. This base class handles channels, initialization of channels and updating from channels, feeding into a generic `UpdateSurface()` function call, to be implemented by child classes. Rather than adding all channels directly, this class performs delta updates on the channels, allowing calculation of the delta to be performed asynchronously between channels. Afterwards, this delta has to be applied synchronously to the DM.

> [!NOTE]  
> Due to floating point arithmetic, the delta updates will not be the same as absolute updates (which would add all channels explicitly), and errors will accumulate over time. However, the errors are negligible. Let's do a computation to figure out how much. With 64-bit numbers we have a 52-bit mantissa. This gives a $2^{-53}\approx10^{-16}$ relative error per floating point operation. So, after a month of continuous operation at 10kHz, we would expect a $\sqrt{10000\times60 \times60\times24\times30}\times10^{-16}\approx10^{-11}$ relative error, equal to 36-bit, far less than our DMs.

This PR also adds functionality for reading FITS files to the C++ core.