### PR TITLE
Submit zero to percent data stream upon startup of Thorlabs CLD

### DIFF
--- a/catkit2/services/thorlabs_cld101x/thorlabs_cld101x.py
+++ b/catkit2/services/thorlabs_cld101x/thorlabs_cld101x.py
@@ -31,6 +31,7 @@ class ThorlabsCLD101X(Service):
         # Turn laser on and set current setpoint to 0.0
         self.connection.write("output1:state on")
         self.connection.write(f"{self._SET_CURRENT}0.0")
+        self.current_percent.submit_data(np.array([0.0], dtype='float32'))
 
         # Read max current setpoint.
         self.max_current = float(self.connection.query('source1:current:limit:amplitude?'))  # in Ampere

--- a/catkit2/services/thorlabs_cld101x_sim/thorlabs_cld101x_sim.py
+++ b/catkit2/services/thorlabs_cld101x_sim/thorlabs_cld101x_sim.py
@@ -13,6 +13,7 @@ class ThorlabsCLD101XSim(Service):
         self.current_percent = self.make_data_stream(f'current_percent_{self.wavelength}', 'float32', [1], 20)
 
     def open(self):
+        self.current_percent.submit_data(np.array([0.0], dtype='float32'))
         self.max_current = 0.25  # in Ampere  # TODO: Get this from config?
 
     def main(self):


### PR DESCRIPTION
In this way, we can read a non-empty data stream right after starting up the service, which should return zero if the laser hasn't been set to anything else yet.

Edit: Tested in sim.