### PR TITLE
Recreate shared memory for message broker if it already exists.

### DIFF
--- a/catkit2/bindings.cpp
+++ b/catkit2/bindings.cpp
@@ -891,6 +891,7 @@ PYBIND11_MODULE(catkit_bindings, m)
 			auto mem = SharedMemory::Open(name);
 			return std::shared_ptr<SharedMemory>(std::move(mem));
 		})
+		.def("destroy", &SharedMemory::Destroy)
 		.def("get_memory", [](std::shared_ptr<SharedMemory> memory)
 		{
 			auto address = memory->GetAddress();

--- a/catkit2/testbed/testbed.py
+++ b/catkit2/testbed/testbed.py
@@ -7,7 +7,7 @@ import socket
 import threading
 import contextlib
 import importlib
-import filelock
+import fasteners
 
 import psutil
 import zmq
@@ -223,7 +223,9 @@ class Testbed:
         else:
             lock_path = f'/tmp/catkit2_{port}.lock'
 
-        self.lock = filelock.FileLock(lock_path)
+        self.lock = fasteners.InterProcessLock(lock_path)
+        if not self.lock.acquire(blocking=False):
+            raise RuntimeError(f'Another testbed object is already running on port {port}.')
 
         self.host_name = get_host_name()
 

--- a/catkit2/testbed/testbed.py
+++ b/catkit2/testbed/testbed.py
@@ -7,6 +7,7 @@ import socket
 import threading
 import contextlib
 import importlib
+import filelock
 
 import psutil
 import zmq
@@ -196,6 +197,14 @@ class Testbed:
         self.host = '127.0.0.1'
         self.port = port
 
+        # Set a lock file so that no more than one testbed object exists for a specific port.
+        if os.name == 'nt':
+            lock_path = os.path.join(os.getenv('TEMP'), f'catkit2_{port}.lock')
+        else:
+            lock_path = f'/tmp/catkit2_{port}.lock'
+
+        self.lock = filelock.FileLock(lock_path)
+
         self.host_name = get_host_name()
 
         self.logging_ingress_port = 0
@@ -303,8 +312,8 @@ class Testbed:
         self.heartbeat_stream = DataStream.create('heartbeat', 'testbed', 'uint64', [1], 20)
 
         # Create a message broker.
-        self.message_broker_header = SharedMemory.create(f'catkit_broker_{port}', 1024 * 1024 * 256)
-        self.message_broker_buffer = SharedMemory.create(f'catkit_broker_{port}_buffer', 1024 * 1024 * 1024 * 2)
+        self.message_broker_header = SharedMemory.create(f'catkit_broker_{port}.hdr', 1024 * 1024 * 256)
+        self.message_broker_buffer = SharedMemory.create(f'catkit_broker_{port}.buf', 1024 * 1024 * 1024 * 2)
 
         self.message_broker = MessageBroker.create(self.message_broker_header, [self.message_broker_buffer])
 

--- a/catkit2/testbed/testbed.py
+++ b/catkit2/testbed/testbed.py
@@ -77,6 +77,26 @@ def get_unused_port(num_ports=1):
     return ports
 
 
+def create_shared_memory(name, size):
+    '''Create an empty shared memory object, even if it already existed.
+
+    Parameters
+    ----------
+    name : str
+        The name of the shared memory object.
+    size : int
+        The size in bytes of the shared memory object.
+    '''
+    try:
+        return SharedMemory.create(name, size)
+    except RuntimeError:
+        # Try to open and destroy and try again.
+        shm = SharedMemory.open(name)
+        shm.destroy()
+
+        return SharedMemory.create(name, size)
+
+
 class ServiceReference:
     '''A reference to a service running on another process.
 
@@ -312,8 +332,8 @@ class Testbed:
         self.heartbeat_stream = DataStream.create('heartbeat', 'testbed', 'uint64', [1], 20)
 
         # Create a message broker.
-        self.message_broker_header = SharedMemory.create(f'catkit_broker_{port}.hdr', 1024 * 1024 * 256)
-        self.message_broker_buffer = SharedMemory.create(f'catkit_broker_{port}.buf', 1024 * 1024 * 1024 * 2)
+        self.message_broker_header = create_shared_memory(f'catkit_broker_{port}.hdr', 1024 * 1024 * 256)
+        self.message_broker_buffer = create_shared_memory(f'catkit_broker_{port}.buf', 1024 * 1024 * 1024 * 2)
 
         self.message_broker = MessageBroker.create(self.message_broker_header, [self.message_broker_buffer])
 

--- a/catkit_core/SharedMemory.cpp
+++ b/catkit_core/SharedMemory.cpp
@@ -224,6 +224,15 @@ SharedMemory::SharedMemory(std::string_view fname, FileObject file, bool is_owne
 #endif // _WIN32
 }
 
+void SharedMemory::Destroy()
+{
+#ifdef _WIN32
+	throw std::runtime_error("Destroying shared memory is not possible on Windows. Close the process using the shared memory instead.");
+#else
+	shm_unlink(m_FileName.c_str());
+#endif
+}
+
 void *SharedMemory::GetAddress(std::size_t offset)
 {
 	return static_cast<char *>(m_Buffer) + sizeof(Header) + offset;

--- a/catkit_core/SharedMemory.h
+++ b/catkit_core/SharedMemory.h
@@ -55,6 +55,9 @@ public:
 	static std::shared_ptr<SharedMemory> Open(StructStream &stream);
 	static std::shared_ptr<SharedMemory> Open(std::string_view fname);
 
+	// Destroy the shared memory object, even if we are not the owner.
+	void Destroy();
+
 	virtual void *GetAddress(std::size_t offset = 0) override;
 	virtual std::size_t GetCapacity() const override;
 	virtual void WriteReference(StructStream &stream) override;

--- a/environment.yml
+++ b/environment.yml
@@ -44,6 +44,7 @@ dependencies:
   - flake8
   - h5py
   - importlib_metadata
+  - fasteners
   - pip:
     - dcps
     - zwoasi>=0.0.21


### PR DESCRIPTION
In some cases, the shared memory used by the message broker already exists.  In this case, the creation of a shared memory block will fail. This is intended: 

This is in cases where the shared memory block was somehow not destroyed correctly after the process shut down. For example when the testbed crashes or somehow cleanup wasn't performed. In these cases, we're left with a dangling shared memory block that prevents the testbed from starting again.

This PR uses a file lock (a lock which gets unlocked automatically, even when the process exits prematurely) to establish whether it can reuse the shared memory block. If this lock is not held, a new testbed server will acquire it and afterwards be allowed to recreate a shared memory block, even if it already exists.