### PR TITLE
Publish messages regarding service state and heartbeats.

### DIFF
--- a/catkit2/testbed/testbed.py
+++ b/catkit2/testbed/testbed.py
@@ -266,6 +266,12 @@ class Testbed:
         if self.is_simulated:
             self.startup_services.append('simulator')
 
+        # Create a message broker.
+        self.message_broker_header = create_shared_memory(f'catkit_broker_{port}.hdr', 1024 * 1024 * 1024)
+        self.message_broker_buffer = create_shared_memory(f'catkit_broker_{port}.buf', 1024 * 1024 * 1024 * 2)
+
+        self.message_broker = LocalMessageBroker.create(self.message_broker_header, [self.message_broker_buffer])
+
         # Fill in services dictionary.
         for service_id, service_info in self.config['services'].items():
             service_type = service_info['service_type']
@@ -345,12 +351,6 @@ class Testbed:
         self.shutdown_flag = threading.Event()
 
         self.heartbeat_stream = DataStream.create('heartbeat', 'testbed', 'uint64', [1], 20)
-
-        # Create a message broker.
-        self.message_broker_header = create_shared_memory(f'catkit_broker_{port}.hdr', 1024 * 1024 * 1024)
-        self.message_broker_buffer = create_shared_memory(f'catkit_broker_{port}.buf', 1024 * 1024 * 1024 * 2)
-
-        self.message_broker = LocalMessageBroker.create(self.message_broker_header, [self.message_broker_buffer])
 
     def run(self):
         '''Run the main loop of the server.

--- a/catkit2/testbed/testbed.py
+++ b/catkit2/testbed/testbed.py
@@ -111,9 +111,10 @@ class ServiceReference:
     state : ServiceState
         The current state of the service.
     '''
-    def __init__(self, service_id, service_type, state, dependencies):
+    def __init__(self, service_id, service_type, state, dependencies, broker):
         self.service_id = service_id
         self.service_type = service_type
+        self.broker = broker
 
         if dependencies is None:
             dependencies = []
@@ -140,6 +141,8 @@ class ServiceReference:
     def state(self, state):
         new_state = np.array([state.value], dtype='int8')
         self.state_stream.submit_data(new_state)
+
+        self.broker.publish_array(f'{self.service_id}/service_state/get', new_state)
 
     @property
     def is_alive(self):
@@ -272,7 +275,7 @@ class Testbed:
 
             dependencies = service_info.get('depends_on', [])
 
-            self.services[service_id] = ServiceReference(service_id, service_type, ServiceState.CLOSED, dependencies)
+            self.services[service_id] = ServiceReference(service_id, service_type, ServiceState.CLOSED, dependencies, self.message_broker)
 
         # Set up dependency management.
         for service_id, service in self.services.items():
@@ -429,6 +432,8 @@ class Testbed:
 
             heartbeat = np.array([get_timestamp()], dtype='uint64')
             self.heartbeat_stream.submit_data(heartbeat)
+
+            self.message_broker.publish_array('testbed/heartbeat/get', heartbeat)
 
     def monitor_services(self):
         while not self.shutdown_flag.is_set():

--- a/catkit2/tui/mtop.py
+++ b/catkit2/tui/mtop.py
@@ -5,10 +5,58 @@ from textual.widgets.data_table import CellDoesNotExist
 from rich.text import Text
 from rich.console import ConsoleRenderable
 
+# For Python 3.7 workaround.
+from textual._two_way_dict import TwoWayDict
+from operator import itemgetter
+
 import sys
 import numpy as np
 
 from catkit2.catkit_bindings import SharedMemory, LocalMessageBroker, get_timestamp
+def sort_data_table(
+    data_table,
+    *columns,
+    key,
+    reverse):
+    """Sort the rows in the `DataTable` by one or more column keys or a
+    key function (or other callable). If both columns and a key function
+    are specified, only data from those columns will sent to the key function.
+
+    NOTE: This is copy-pasted and then adapted from Textual. This function is
+    natively implemented in newer versions, but for versions compatible with
+    Python 3.7, the key keyword is not availble.
+
+    Args:
+        columns: One or more columns to sort by the values in.
+        key: A function (or other callable) that returns a key to
+            use for sorting purposes.
+        reverse: If True, the sort order will be reversed.
+
+    Returns:
+        The `DataTable` instance.
+    """
+
+    def key_wrapper(row):
+        _, row_data = row
+        if columns:
+            result = itemgetter(*columns)(row_data)
+        else:
+            result = tuple(row_data.values())
+        if key is not None:
+            return key(result)
+        return result
+
+    ordered_rows = sorted(
+        data_table._data.items(),
+        key=key_wrapper,
+        reverse=reverse,
+    )
+    data_table._row_locations = TwoWayDict(
+        {row_key: new_index for new_index, (row_key, _) in enumerate(ordered_rows)}
+    )
+    data_table._update_count += 1
+    data_table.refresh()
+    return data_table
 
 def human_readable_time(seconds):
     seconds = round(seconds)
@@ -126,7 +174,11 @@ class MTopApp(App):
         elif self.current_sort_column == 'frame_rate':
             reverse = True
 
-        self.table.sort(self.current_sort_column, key=key, reverse=reverse)
+        try:
+            self.table.sort(self.current_sort_column, key=key, reverse=reverse)
+        except TypeError:
+            # Workaround for Python 3.7.
+            sort_data_table(self.table, self.current_sort_column, key=key, reverse=reverse)
 
     def action_sort_by_topic(self):
         self.current_sort_column = 'topic'

--- a/catkit2/tui/mtop.py
+++ b/catkit2/tui/mtop.py
@@ -84,7 +84,7 @@ class MTopApp(App):
         self.current_sort_column = 'topic'
 
     def compose(self) -> ComposeResult:
-        yield Header(icon='')
+        yield Header()
 
         self.table = DataTable(id="datatable")
         yield Container(self.table)

--- a/catkit_core/Service.cpp
+++ b/catkit_core/Service.cpp
@@ -131,6 +131,9 @@ void Service::Run(void (*error_check)())
 		std::uint64_t timestamp = GetTimeStamp();
 		m_Heartbeat->SubmitData(&timestamp);
 
+		ArrayInfo info{'u', '=', 8, 1, {1, 1, 1, 1}, {8, 1, 1, 1}};
+		m_Testbed->GetMessageBroker()->PublishArray(m_ServiceId + "/heartbeat/get", {info, &timestamp});
+
 		// Start the safety and heartbeat threads.
 		std::thread safety(&Service::MonitorSafety, this);
 		std::thread heartbeat(&Service::MonitorHeartbeats, this);
@@ -210,6 +213,10 @@ void Service::Run(void (*error_check)())
 	// Set heartbeat timestamp to zero to signal a dead service.
 	std::uint64_t timestamp = 0;
 	m_Heartbeat->SubmitData(&timestamp);
+
+	ArrayInfo info{'u', '=', 8, 1, {1, 1, 1, 1}, {8, 1, 1, 1}};
+	m_Testbed->GetMessageBroker()->PublishArray(m_ServiceId + "/heartbeat/get", {info, &timestamp});
+
 
 	CleanupAttributes();
 }
@@ -296,6 +303,9 @@ void Service::MonitorHeartbeats()
 		// Update my own heartbeat.
 		std::uint64_t timestamp = GetTimeStamp();
 		m_Heartbeat->SubmitData(&timestamp);
+
+		ArrayInfo info{'u', '=', 8, 1, {1, 1, 1, 1}, {8, 1, 1, 1}};
+		m_Testbed->GetMessageBroker()->PublishArray(m_ServiceId + "/heartbeat/get", {info, &timestamp});
 
 		// Check the testbed heartbeat.
 		if (!m_Testbed->IsAlive())


### PR DESCRIPTION
> [!CAUTION]
> This PR requires #340 and #346 to be merged before.

For both the testbed server heartbeats and service states/heartbeats. I'm still debating on whether to fully switch over to the message broker for this functionality, or to keep both for now.
~~WIP: Found some bugs in the message broker that need to be fixed before merging this, but this has allowed me to find them.~~ Bugs are fixed in #340 and #346.

~~Also, needs to be rebased badly, I know.~~ Rebased!