### PR TITLE
Fix for HybridPoolAllocator wrongly removing pools.

### DIFF
--- a/catkit_core/BuddyAllocator.cpp
+++ b/catkit_core/BuddyAllocator.cpp
@@ -171,7 +171,8 @@ BuddyAllocator::Handle BuddyAllocator::Allocate(std::size_t size)
 
 			if (failed_at == INVALID_HANDLE)
 			{
-				DEBUG_PRINT("Sucessful at node " << i);
+				DEBUG_PRINT("Successful at node " << i);
+				DEBUG_PRINT("Ref count = " << (m_Tree[i].load(std::memory_order_relaxed) & REF_MASK));
 
 				m_LastSuccessfulAllocation[level].store(i, std::memory_order_relaxed);
 				return i;
@@ -193,16 +194,23 @@ BuddyAllocator::Handle BuddyAllocator::Allocate(std::size_t size)
 
 bool BuddyAllocator::Acquire(Handle handle)
 {
+	DEBUG_PRINT("Acquiring handle " << handle);
+
+	DEBUG_PRINT("Ref count = " << ((m_Tree[handle].load(std::memory_order_relaxed) & REF_MASK) + 1));
+
 	// Increment the reference counter, but check for zero reference bit.
 	return (m_Tree[handle].fetch_add(1, std::memory_order_relaxed) & REF_ZERO) == 0;
 }
 
 bool BuddyAllocator::Release(Handle handle)
 {
-	DEBUG_PRINT("Deallocating handle " << handle);
+	DEBUG_PRINT("Releasing handle " << handle);
 
 	// Decrement the ref counter.
 	auto old_val = m_Tree[handle].fetch_sub(1, std::memory_order_relaxed);
+
+	DEBUG_PRINT("Decremented ref counter");
+	DEBUG_PRINT("Ref count = " << (m_Tree[handle].load(std::memory_order_relaxed) & REF_MASK));
 
 	if ((old_val & REF_MASK) == 1)
 	{

--- a/catkit_core/HybridPoolAllocator.cpp
+++ b/catkit_core/HybridPoolAllocator.cpp
@@ -3,6 +3,10 @@
 
 #include <array>
 #include <stdexcept>
+#include <iostream>
+
+//#define DEBUG_PRINT(a) std::cout << a << std::endl
+#define DEBUG_PRINT(a)
 
 const std::array<std::uint8_t, 4> HYBRID_POOL_ALLOCATOR_VERSION = {0, 0, 0, 0};
 
@@ -66,6 +70,8 @@ std::size_t HybridPoolAllocator::GetSharedStateSize(std::size_t capacity, std::s
 
 HybridPoolAllocator::Handle HybridPoolAllocator::Allocate(std::size_t size)
 {
+	DEBUG_PRINT("HybridPoolAllocator::Allocate(" << size << ")");
+
 	size = round_up_to_power_of_2(size);
 
 	if (size < m_MinSize)
@@ -73,6 +79,8 @@ HybridPoolAllocator::Handle HybridPoolAllocator::Allocate(std::size_t size)
 
 	if (size >= m_MinSizePool)
 	{
+		DEBUG_PRINT("size is too large for pools");
+
 		// The size is too large to use pools. Defer to the buddy allocator.
 		return m_Allocator->Allocate(size);
 	}
@@ -80,16 +88,21 @@ HybridPoolAllocator::Handle HybridPoolAllocator::Allocate(std::size_t size)
 	std::size_t level = GetLevelFromSize(size);
 	Bucket &bucket = GetBucket(level);
 
+	DEBUG_PRINT("level: " << level);
+
 	// Loop over the pools in the bucket and find a pool with an available slot.
 	for (auto it = bucket.rbegin(); it < bucket.rend(); ++it)
 	{
 		Handle handle = *it;
 		Pool &pool = m_Pools[handle];
 
+		DEBUG_PRINT("pool: " << handle << " " << pool.map);
+
 		auto val_inv = ~(pool.map);
 
 		if (val_inv == 0)
 		{
+			DEBUG_PRINT("pool is full");
 			// No slots available in this pool. Move to the next.
 			continue;
 		}
@@ -101,15 +114,24 @@ HybridPoolAllocator::Handle HybridPoolAllocator::Allocate(std::size_t size)
 
 		if (~(pool.map) == 0)
 		{
+			DEBUG_PRINT("pool became full");
+
+			// No slots available in this pool. Move to the
 			// The pool is full. Remove it from the bucket.
 			bucket.erase(std::next(it).base());
 		}
 
+		DEBUG_PRINT("returning " << (handle << 6) + sub_handle);
+
 		// Set the reference count.
 		pool.ref_counts[sub_handle].Reset();
 
+		DEBUG_PRINT("Reset reference count to 1");
+
 		return (handle << 6) + sub_handle;
 	}
+
+	DEBUG_PRINT("no slot available, allocating new pool.");
 
 	// No slot in any pool was available. Allocate a new pool.
 	auto new_handle = m_Allocator->Allocate(size * 64);
@@ -126,6 +148,8 @@ HybridPoolAllocator::Handle HybridPoolAllocator::Allocate(std::size_t size)
 	// Set the map and reset the reference count of this slot.
 	pool.map = 1;
 	pool.ref_counts[0].Reset();
+
+	DEBUG_PRINT("set pool parameters and returning " << new_handle);
 
 	return new_handle << 6;
 }
@@ -158,28 +182,41 @@ bool HybridPoolAllocator::Acquire(Handle handle)
 
 bool HybridPoolAllocator::Release(Handle handle)
 {
+	DEBUG_PRINT("Releasing " << handle);
+
 	// Get the level of this block.
 	std::size_t level = GetLevelFromHandle(handle);
 
 	// Get the size of blocks at this level.
 	std::size_t size = m_Capacity >> level;
 
+	DEBUG_PRINT("Level " << level << ", size " << size);
+
 	if (size >= m_MinSizePool)
 	{
+		DEBUG_PRINT("Block is in the parent allocator. Releasing it from there.");
+
 		// This is a block in the allocator.
 		return m_Allocator->Release(handle);
 	}
 	else
 	{
+		DEBUG_PRINT("Block is in one of our pools.");
+
 		// This is a block in one of our pools. Find cache handle and sub handle.
 		BuddyAllocator::Handle pool_handle = handle >> 6;
 		Handle sub_handle = (handle & ((1 << 6) - 1));
 		std::uint64_t mask = 1ull << sub_handle;
 
+		DEBUG_PRINT("Pool handle " << pool_handle << ", sub handle " << sub_handle);
+		DEBUG_PRINT("Mask " << mask);
+
 		Pool &pool = m_Pools[pool_handle];
 
 		if (!pool.ref_counts[sub_handle].Decrement())
 		{
+			DEBUG_PRINT("Block still has references.");
+
 			// Someone else is still owning this slot. Return.
 			return false;
 		}
@@ -190,6 +227,8 @@ bool HybridPoolAllocator::Release(Handle handle)
 		// we free the slot.
 		if (~(pool.map) == 0)
 		{
+			DEBUG_PRINT("Pool will have a new empty slot. Adding back to the bucket.");
+
 			bucket.emplace_back(pool_handle);
 		}
 
@@ -205,6 +244,8 @@ bool HybridPoolAllocator::Release(Handle handle)
 			auto it = std::find(bucket.begin(), bucket.end(), pool_handle);
 			bucket.erase(it);
 		}
+
+		DEBUG_PRINT("Successful deallocation.");
 
 		return true;
 	}

--- a/catkit_core/HybridPoolAllocator.cpp
+++ b/catkit_core/HybridPoolAllocator.cpp
@@ -15,6 +15,22 @@ HybridPoolAllocator::HybridPoolAllocator(std::size_t capacity, std::size_t min_s
 {
 }
 
+HybridPoolAllocator::~HybridPoolAllocator()
+{
+	// Release all pools.
+	// The pools will be deallocated when all slots are released.
+	for (size_t i = 0; i < m_Buckets.Size(); ++i)
+	{
+		auto &buckets = m_Buckets[i];
+
+		for (auto &bucket : buckets)
+		{
+			for (auto &pool : bucket)
+				m_Allocator->Release(pool);
+		}
+	}
+}
+
 std::shared_ptr<HybridPoolAllocator> HybridPoolAllocator::Create(StructStream &stream, std::size_t capacity, std::size_t min_size, std::size_t min_size_pool)
 {
 	*stream.Extract<std::array<std::uint8_t, 4>>() = HYBRID_POOL_ALLOCATOR_VERSION;

--- a/catkit_core/HybridPoolAllocator.cpp
+++ b/catkit_core/HybridPoolAllocator.cpp
@@ -26,9 +26,16 @@ HybridPoolAllocator::~HybridPoolAllocator()
 		for (auto &bucket : buckets)
 		{
 			for (auto &pool : bucket)
+			{
+				DEBUG_PRINT("Releasing pool " << pool);
+
 				m_Allocator->Release(pool);
+			}
+			DEBUG_PRINT("Done with bucket.");
 		}
+		DEBUG_PRINT("Done with buckets for this thread.");
 	}
+	DEBUG_PRINT("Done with all buckets.");
 }
 
 std::shared_ptr<HybridPoolAllocator> HybridPoolAllocator::Create(StructStream &stream, std::size_t capacity, std::size_t min_size, std::size_t min_size_pool)
@@ -114,9 +121,8 @@ HybridPoolAllocator::Handle HybridPoolAllocator::Allocate(std::size_t size)
 
 		DEBUG_PRINT("pool: " << handle << " " << pool.map);
 
-		// Attempt to increment the ref counter of the pool before we start messing with it.
-		if (!m_Allocator->Acquire(handle))
-			continue;
+		// Increment the ref counter of the pool before we start messing with it.
+		m_Allocator->Acquire(handle);
 
 		auto val_inv = ~(pool.map);
 
@@ -175,13 +181,15 @@ HybridPoolAllocator::Handle HybridPoolAllocator::Allocate(std::size_t size)
 	pool.map = 1;
 	pool.ref_counts[0].Reset();
 
-	DEBUG_PRINT("set pool parameters and returning " << new_handle);
+	DEBUG_PRINT("set pool parameters and returning " << (new_handle << 6));
 
 	return new_handle << 6;
 }
 
 bool HybridPoolAllocator::Acquire(Handle handle)
 {
+	DEBUG_PRINT("Acquiring " << handle);
+
 	// Get the level of this block.
 	std::size_t level = GetLevelFromHandle(handle);
 
@@ -201,7 +209,6 @@ bool HybridPoolAllocator::Acquire(Handle handle)
 		std::uint64_t mask = 1ull << sub_handle;
 
 		Pool &pool = m_Pools[pool_handle];
-
 		return pool.ref_counts[sub_handle].Increment();
 	}
 }

--- a/catkit_core/HybridPoolAllocator.cpp
+++ b/catkit_core/HybridPoolAllocator.cpp
@@ -98,11 +98,18 @@ HybridPoolAllocator::Handle HybridPoolAllocator::Allocate(std::size_t size)
 
 		DEBUG_PRINT("pool: " << handle << " " << pool.map);
 
+		// Attempt to increment the ref counter of the pool before we start messing with it.
+		if (!m_Allocator->Acquire(handle))
+			continue;
+
 		auto val_inv = ~(pool.map);
 
 		if (val_inv == 0)
 		{
 			DEBUG_PRINT("pool is full");
+
+			m_Allocator->Release(handle);
+
 			// No slots available in this pool. Move to the next.
 			continue;
 		}
@@ -140,6 +147,9 @@ HybridPoolAllocator::Handle HybridPoolAllocator::Allocate(std::size_t size)
 	{
 		throw std::runtime_error("Failed to allocate a new pool.");
 	}
+
+	// Increment ref count for the slot in the pool.
+	m_Allocator->Acquire(new_handle);
 
 	Pool &pool = m_Pools[new_handle];
 
@@ -235,9 +245,15 @@ bool HybridPoolAllocator::Release(Handle handle)
 		// Update the pool bitmap.
 		pool.map &= ~mask;
 
+		// Decrement the ref count of the pool to account for the slot being released.
+		m_Allocator->Release(pool_handle);
+
 		if (pool.map == 0)
 		{
 			DEBUG_PRINT("Pool is now fully empty. Releasing the pool itself.");
+
+			// Release the pool. We're the owner so we are guaranteed to be successful.
+			m_Allocator->Release(pool_handle);
 
 			DEBUG_PRINT("Also removing the pool from our bucket.");
 			DEBUG_PRINT("Searching for " << pool_handle);
@@ -249,14 +265,10 @@ bool HybridPoolAllocator::Release(Handle handle)
 
 			auto it = std::find(bucket.begin(), bucket.end(), pool_handle);
 
-			// Only release the pool if we own the bucket. Otherwise, the original owner will
-			// reuse it.
+			// Check if we own the pool (ie. if it was in our bucket).
 			if (it != bucket.end())
 			{
-				// Release the pool.
-				m_Allocator->Release(pool_handle);
-
-				// Remove the pool rom the bucket.
+				// Remove the pool from our bucket so that we don't reuse it anymore.
 				bucket.erase(it);
 			}
 

--- a/catkit_core/HybridPoolAllocator.cpp
+++ b/catkit_core/HybridPoolAllocator.cpp
@@ -237,12 +237,30 @@ bool HybridPoolAllocator::Release(Handle handle)
 
 		if (pool.map == 0)
 		{
-			// The pool is now empty.
-			m_Allocator->Release(pool_handle);
+			DEBUG_PRINT("Pool is now fully empty. Releasing the pool itself.");
 
-			// Find the pool in the bucket.
+			DEBUG_PRINT("Also removing the pool from our bucket.");
+			DEBUG_PRINT("Searching for " << pool_handle);
+			DEBUG_PRINT("Bucket: ");
+			for (auto &pool_handle : bucket)
+			{
+				DEBUG_PRINT("  " << pool_handle);
+			}
+
 			auto it = std::find(bucket.begin(), bucket.end(), pool_handle);
-			bucket.erase(it);
+
+			// Only release the pool if we own the bucket. Otherwise, the original owner will
+			// reuse it.
+			if (it != bucket.end())
+			{
+				// Release the pool.
+				m_Allocator->Release(pool_handle);
+
+				// Remove the pool rom the bucket.
+				bucket.erase(it);
+			}
+
+			DEBUG_PRINT("Done.");
 		}
 
 		DEBUG_PRINT("Successful deallocation.");

--- a/catkit_core/HybridPoolAllocator.h
+++ b/catkit_core/HybridPoolAllocator.h
@@ -42,6 +42,7 @@ public:
 
 public:
 	HybridPoolAllocator(std::size_t capacity, std::size_t min_size, std::size_t min_size_pool, std::shared_ptr<BuddyAllocator> allocator, Pool *pools);
+	~HybridPoolAllocator();
 
 	std::size_t GetLevelFromHandle(Handle handle) const;
 	std::size_t GetLevelFromSize(std::size_t size) const;

--- a/tests/test_message_broker.py
+++ b/tests/test_message_broker.py
@@ -2,12 +2,19 @@ from catkit2.catkit_bindings import LocalMemory, MessageBroker, MessageSubscript
 import numpy as np
 import pytest
 
+# Allocate memory for the header. Doing this in a separate fixture
+# ensures that the memory is not deallocated until the objects inside
+# are.
 @pytest.fixture(scope='module')
-def broker():
+def header_memory():
     header = LocalMemory.create(1024 * 1024 * 512)
+    yield header
+
+@pytest.fixture(scope='module')
+def broker(header_memory):
     block = LocalMemory.create(1024 * 1024 * 1024)
 
-    broker = MessageBroker.create(header, [block])
+    broker = MessageBroker.create(header_memory, [block])
     yield broker
 
 def test_message_subscription(broker):


### PR DESCRIPTION
When the last slot on a pool was released, the pool will be released. This was done regardless of whether the pool was owned by the process or not, leading to a segmentation fault or bus error when the process didn't own the pool.

Pools are allocated blocks on the BuddyAllocator. Each pool has 64 slots, which the HybridPoolAllocator hands out. Each of the slots are reference counted by the HybridPoolAllocator. Slots are deallocated once the reference count reaches zero. Each of the pools are reference counted by the BuddyAllocator. The number of references to a Pool is 1 + N_allocated_slots, so at most 65. This PR adds proper reference counting for the Pools, which was done incorrectly.

Todo:
- [x] The pools of destroyed allocator objects should also be deallocated automatically after all references are released.