### PR TITLE
Use interface for `MessageBroker`.

### DIFF
--- a/benchmarks/message_broker.cpp
+++ b/benchmarks/message_broker.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 
-#include "MessageBroker.h"
 #include "LocalMemory.h"
+#include "LocalMessageBroker.h"
 
 const size_t NUM_MESSAGES = 10000000;
 

--- a/benchmarks/message_broker.cpp
+++ b/benchmarks/message_broker.cpp
@@ -13,7 +13,7 @@ int main(int argc, char *argv[])
 	std::vector<std::shared_ptr<Memory>> memory_blocks;
 	memory_blocks.push_back(LocalMemory::Create(stream, 1024 * 1024 * 128));
 
-	auto message_broker = MessageBroker::Create(stream, memory_blocks);
+	auto message_broker = LocalMessageBroker::Create(stream, memory_blocks);
 
 	std::cout << "Message broker size: " << stream.GetOffset() << std::endl;
 

--- a/catkit2/bindings.cpp
+++ b/catkit2/bindings.cpp
@@ -1092,15 +1092,15 @@ PYBIND11_MODULE(catkit_bindings, m)
 	py::class_<LocalMessageBroker, std::shared_ptr<LocalMessageBroker>>(m, "LocalMessageBroker")
 		.def_static("create", [](std::shared_ptr<Memory> header, std::vector<std::shared_ptr<Memory>> memory_blocks)
 		{
-			auto stream = StructStream(header->GetAddress());
-			auto broker = MessageBroker::Create(stream, memory_blocks);
+			auto stream = StructStream(header);
+			auto broker = LocalMessageBroker::Create(stream, memory_blocks);
 
 			return std::shared_ptr<LocalMessageBroker>(std::move(broker));
 		})
 		.def_static("open", [](std::shared_ptr<Memory> memory)
 		{
-			auto stream = StructStream(memory->GetAddress());
-			auto broker = MessageBroker::Open(stream);
+			auto stream = StructStream(memory);
+			auto broker = LocalMessageBroker::Open(stream);
 
 			return std::shared_ptr<LocalMessageBroker>(std::move(broker));
 		})

--- a/catkit2/bindings.cpp
+++ b/catkit2/bindings.cpp
@@ -24,7 +24,7 @@
 #include "Client.h"
 #include "HostName.h"
 #include "Tracing.h"
-#include "MessageBroker.h"
+#include "LocalMessageBroker.h"
 #include "LocalMemory.h"
 #include "SharedMemory.h"
 #include "Shareable.h"

--- a/catkit2/bindings.cpp
+++ b/catkit2/bindings.cpp
@@ -1136,7 +1136,7 @@ PYBIND11_MODULE(catkit_bindings, m)
 				broker->PublishData(topic, PyBytes_AsString(data.ptr()), PyBytes_Size(data.ptr()), py::cast<Uuid>(trace_id), memory_block_id);
 			}
 		}, py::arg("topic"), py::arg("data"), py::arg("trace_id") = py::none(), py::arg("memory_block_id") = 0)
-		.def("publish_array", [](std::shared_ptr<MessageBroker> broker, std::string topic, py::array array, py::object trace_id, std::uint8_t memory_block_id)
+		.def("publish_array", [](std::shared_ptr<LocalMessageBroker> broker, std::string topic, py::array array, py::object trace_id, std::uint8_t memory_block_id)
 		{
 			ArrayInfo info;
 

--- a/catkit2/bindings.cpp
+++ b/catkit2/bindings.cpp
@@ -983,6 +983,8 @@ PYBIND11_MODULE(catkit_bindings, m)
 	py::class_<Message>(m, "Message")
 		.def_property_readonly("topic", &Message::GetTopic)
 		.def_property_readonly("trace_id", &Message::GetTraceId)
+		.def_property_readonly("frame_id", &Message::GetFrameId)
+		.def_property_readonly("partial_frame_id", &Message::GetPartialFrameId)
 		.def_property_readonly("payload_id", &Message::GetPayloadId)
 		.def_property_readonly("producer_hostname", &Message::GetProducerHostname)
 		.def_property_readonly("producer_pid", &Message::GetProducerPid)
@@ -1190,18 +1192,18 @@ PYBIND11_MODULE(catkit_bindings, m)
 		.def("get_oldest_message_id", &LocalMessageBroker::GetOldestMessageId)
 		.def("get_message_rate", &LocalMessageBroker::GetMessageRate)
 		.def("get_all_message_topics", &LocalMessageBroker::GetAllMessageTopics)
-		.def("subscribe", [](std::shared_ptr<LocalMessageBroker> broker, std::string topic, py::object starting_frame_id, MessageSubscriptionMode mode)
+		.def("subscribe", [](std::shared_ptr<LocalMessageBroker> broker, std::string topic, py::object preferred_next_frame_id, MessageSubscriptionMode mode)
 		{
 			// Check if the starting frame ID is a number or None.
-			if (starting_frame_id.is_none())
+			if (preferred_next_frame_id.is_none())
 			{
 				return broker->Subscribe(topic, mode);
 			}
 			else
 			{
-				return broker->Subscribe(topic, py::cast<std::uint64_t>(starting_frame_id), mode);
+				return broker->Subscribe(topic, py::cast<std::uint64_t>(preferred_next_frame_id), mode);
 			}
-		}, py::arg("topic"), py::arg("starting_frame_id") = py::none(), py::arg("mode") = MessageSubscriptionMode::NewestOnly);
+		}, py::arg("topic"), py::arg("preferred_next_frame_id") = py::none(), py::arg("mode") = MessageSubscriptionMode::NewestOnly);
 
 	py::class_<PoolAllocator, std::shared_ptr<PoolAllocator>>(m, "PoolAllocator")
 		.def_static("create", [](std::shared_ptr<Memory> memory, std::uint32_t capacity)

--- a/catkit2/bindings.cpp
+++ b/catkit2/bindings.cpp
@@ -1088,28 +1088,28 @@ PYBIND11_MODULE(catkit_bindings, m)
 		})
 		.def_property_readonly("next_message_id", &MessageSubscription::GetNextMessageId);
 
-	py::class_<MessageBroker, std::shared_ptr<MessageBroker>>(m, "MessageBroker")
+	py::class_<LocalMessageBroker, std::shared_ptr<LocalMessageBroker>>(m, "LocalMessageBroker")
 		.def_static("create", [](std::shared_ptr<Memory> header, std::vector<std::shared_ptr<Memory>> memory_blocks)
 		{
-			auto stream = StructStream(header);
+			auto stream = StructStream(header->GetAddress());
 			auto broker = MessageBroker::Create(stream, memory_blocks);
 
-			return std::shared_ptr<MessageBroker>(std::move(broker));
+			return std::shared_ptr<LocalMessageBroker>(std::move(broker));
 		})
 		.def_static("open", [](std::shared_ptr<Memory> memory)
 		{
-			auto stream = StructStream(memory);
+			auto stream = StructStream(memory->GetAddress());
 			auto broker = MessageBroker::Open(stream);
 
-			return std::shared_ptr<MessageBroker>(std::move(broker));
+			return std::shared_ptr<LocalMessageBroker>(std::move(broker));
 		})
-		.def("prepare_message", [](std::shared_ptr<MessageBroker> broker, const std::string& topic, std::size_t payload_size, std::uint8_t memory_block_id)
+		.def("prepare_message", [](std::shared_ptr<LocalMessageBroker> broker, const std::string& topic, std::size_t payload_size, std::uint8_t memory_block_id)
 		{
 			auto message = broker->PrepareMessage(topic, payload_size, memory_block_id);
 
 			return message;
 		}, py::arg("topic"), py::arg("payload_size"), py::arg("memory_block_id") = 0)
-		.def("prepare_message", [](std::shared_ptr<MessageBroker> broker, const std::string& topic, std::size_t payload_size, py::object trace_id, std::uint8_t memory_block_id)
+		.def("prepare_message", [](std::shared_ptr<LocalMessageBroker> broker, const std::string& topic, std::size_t payload_size, py::object trace_id, std::uint8_t memory_block_id)
 		{
 			if (trace_id.is_none())
 			{
@@ -1120,11 +1120,11 @@ PYBIND11_MODULE(catkit_bindings, m)
 				return broker->PrepareMessage(topic, payload_size, py::cast<Uuid>(trace_id), memory_block_id);
 			}
 		}, py::arg("topic"), py::arg("payload_size"), py::arg("trace_id") = py::none(), py::arg("memory_block_id") = 0)
-		.def("publish_message", [](std::shared_ptr<MessageBroker> broker, Message& message, bool is_final)
+		.def("publish_message", [](std::shared_ptr<LocalMessageBroker> broker, Message& message, bool is_final)
 		{
 			broker->PublishMessage(message, is_final);
 		}, py::arg("message"), py::arg("is_final") = true)
-		.def("publish_data", [](std::shared_ptr<MessageBroker> broker, std::string topic, py::bytes data, py::object trace_id, std::uint8_t memory_block_id)
+		.def("publish_data", [](std::shared_ptr<LocalMessageBroker> broker, std::string topic, py::bytes data, py::object trace_id, std::uint8_t memory_block_id)
 		{
 			if (trace_id.is_none())
 			{
@@ -1169,7 +1169,7 @@ PYBIND11_MODULE(catkit_bindings, m)
 				broker->PublishArray(topic, array_view, py::cast<Uuid>(trace_id), memory_block_id);
 			}
 		}, py::arg("topic"), py::arg("array"), py::arg("trace_id") = py::none(), py::arg("memory_block_id") = 0)
-		.def("try_get_message", [](std::shared_ptr<MessageBroker> broker, std::string_view topic, size_t frame_id) -> py::object
+		.def("try_get_message", [](std::shared_ptr<LocalMessageBroker> broker, std::string_view topic, size_t frame_id) -> py::object
 		{
 			auto res = broker->TryGetMessage(topic, frame_id);
 			if (res)
@@ -1177,7 +1177,7 @@ PYBIND11_MODULE(catkit_bindings, m)
 
 			return py::none();
 		}, py::arg("topic"), py::arg("frame_id"))
-		.def("get_newest_message", [](std::shared_ptr<MessageBroker> broker, std::string_view topic) -> py::object
+		.def("get_newest_message", [](std::shared_ptr<LocalMessageBroker> broker, std::string_view topic) -> py::object
 		{
 			auto res = broker->GetNewestMessage(topic);
 			if (res)
@@ -1185,13 +1185,13 @@ PYBIND11_MODULE(catkit_bindings, m)
 
 			return py::none();
 		}, py::arg("topic"))
-		.def("is_message_available", &MessageBroker::IsMessageAvailable)
-		.def("will_message_be_available", &MessageBroker::WillMessageBeAvailable)
-		.def("get_newest_message_id", &MessageBroker::GetNewestMessageId)
-		.def("get_oldest_message_id", &MessageBroker::GetOldestMessageId)
-		.def("get_message_rate", &MessageBroker::GetMessageRate)
-		.def("get_all_message_topics", &MessageBroker::GetAllMessageTopics)
-		.def("subscribe", [](std::shared_ptr<MessageBroker> broker, std::string topic, py::object starting_frame_id, MessageSubscriptionMode mode)
+		.def("is_message_available", &LocalMessageBroker::IsMessageAvailable)
+		.def("will_message_be_available", &LocalMessageBroker::WillMessageBeAvailable)
+		.def("get_newest_message_id", &LocalMessageBroker::GetNewestMessageId)
+		.def("get_oldest_message_id", &LocalMessageBroker::GetOldestMessageId)
+		.def("get_message_rate", &LocalMessageBroker::GetMessageRate)
+		.def("get_all_message_topics", &LocalMessageBroker::GetAllMessageTopics)
+		.def("subscribe", [](std::shared_ptr<LocalMessageBroker> broker, std::string topic, py::object starting_frame_id, MessageSubscriptionMode mode)
 		{
 			// Check if the starting frame ID is a number or None.
 			if (starting_frame_id.is_none())

--- a/catkit2/bindings.cpp
+++ b/catkit2/bindings.cpp
@@ -1085,8 +1085,7 @@ PYBIND11_MODULE(catkit_bindings, m)
 				return py::cast(res.value());
 
 			return py::none();
-		})
-		.def_property_readonly("next_message_id", &MessageSubscription::GetNextMessageId);
+		});
 
 	py::class_<LocalMessageBroker, std::shared_ptr<LocalMessageBroker>>(m, "LocalMessageBroker")
 		.def_static("create", [](std::shared_ptr<Memory> header, std::vector<std::shared_ptr<Memory>> memory_blocks)
@@ -1103,13 +1102,13 @@ PYBIND11_MODULE(catkit_bindings, m)
 
 			return std::shared_ptr<LocalMessageBroker>(std::move(broker));
 		})
-		.def("prepare_message", [](std::shared_ptr<LocalMessageBroker> broker, const std::string& topic, std::size_t payload_size, std::uint8_t memory_block_id)
+		.def("prepare_message", [](std::shared_ptr<LocalMessageBroker> broker, const std::string& topic, size_t payload_size, std::uint8_t memory_block_id)
 		{
 			auto message = broker->PrepareMessage(topic, payload_size, memory_block_id);
 
 			return message;
 		}, py::arg("topic"), py::arg("payload_size"), py::arg("memory_block_id") = 0)
-		.def("prepare_message", [](std::shared_ptr<LocalMessageBroker> broker, const std::string& topic, std::size_t payload_size, py::object trace_id, std::uint8_t memory_block_id)
+		.def("prepare_message", [](std::shared_ptr<LocalMessageBroker> broker, const std::string& topic, size_t payload_size, py::object trace_id, std::uint8_t memory_block_id)
 		{
 			if (trace_id.is_none())
 			{
@@ -1177,9 +1176,9 @@ PYBIND11_MODULE(catkit_bindings, m)
 
 			return py::none();
 		}, py::arg("topic"), py::arg("frame_id"))
-		.def("get_newest_message", [](std::shared_ptr<LocalMessageBroker> broker, std::string_view topic) -> py::object
+		.def("get_current_message", [](std::shared_ptr<LocalMessageBroker> broker, std::string_view topic) -> py::object
 		{
-			auto res = broker->GetNewestMessage(topic);
+			auto res = broker->GetCurrentMessage(topic);
 			if (res)
 				return py::cast(res.value());
 

--- a/catkit2/testbed/testbed.py
+++ b/catkit2/testbed/testbed.py
@@ -13,7 +13,7 @@ import psutil
 import zmq
 import numpy as np
 
-from ..catkit_bindings import LogForwarder, Server, ServiceState, DataStream, SharedMemory, MessageBroker, get_timestamp, is_alive_state, Client, get_host_name
+from ..catkit_bindings import LogForwarder, Server, ServiceState, DataStream, SharedMemory, LocalMessageBroker, get_timestamp, is_alive_state, Client, get_host_name
 from .logging import *
 from .distributor import ZmqDistributor
 
@@ -337,7 +337,7 @@ class Testbed:
         self.message_broker_header = create_shared_memory(f'catkit_broker_{port}.hdr', 1024 * 1024 * 256)
         self.message_broker_buffer = create_shared_memory(f'catkit_broker_{port}.buf', 1024 * 1024 * 1024 * 2)
 
-        self.message_broker = MessageBroker.create(self.message_broker_header, [self.message_broker_buffer])
+        self.message_broker = LocalMessageBroker.create(self.message_broker_header, [self.message_broker_buffer])
 
     def run(self):
         '''Run the main loop of the server.

--- a/catkit2/testbed/testbed.py
+++ b/catkit2/testbed/testbed.py
@@ -334,7 +334,7 @@ class Testbed:
         self.heartbeat_stream = DataStream.create('heartbeat', 'testbed', 'uint64', [1], 20)
 
         # Create a message broker.
-        self.message_broker_header = create_shared_memory(f'catkit_broker_{port}.hdr', 1024 * 1024 * 256)
+        self.message_broker_header = create_shared_memory(f'catkit_broker_{port}.hdr', 1024 * 1024 * 1024)
         self.message_broker_buffer = create_shared_memory(f'catkit_broker_{port}.buf', 1024 * 1024 * 1024 * 2)
 
         self.message_broker = LocalMessageBroker.create(self.message_broker_header, [self.message_broker_buffer])

--- a/catkit2/tui/mtop.py
+++ b/catkit2/tui/mtop.py
@@ -3,7 +3,7 @@ import time
 import sys
 import numpy as np
 
-from catkit2.catkit_bindings import SharedMemory, MessageBroker, get_timestamp
+from catkit2.catkit_bindings import SharedMemory, LocalMessageBroker, get_timestamp
 
 def human_readable_time(seconds):
     seconds = round(seconds)
@@ -80,7 +80,7 @@ def main():
     shared_memory_id = args[1]
 
     header = SharedMemory.open(shared_memory_id)
-    broker = MessageBroker.open(header)
+    broker = LocalMessageBroker.open(header)
 
     DATA_KEYS = ["topic", "pid", "last_updated", "frame_rate", "shape", "dtype", "value"]
     SORT_OPTIONS = DATA_KEYS.copy()

--- a/catkit_core/LocalMessageBroker.cpp
+++ b/catkit_core/LocalMessageBroker.cpp
@@ -265,18 +265,6 @@ std::size_t LocalMessageBroker::CalculateBufferSize()
 	return 0;
 }
 
-Message LocalMessageBroker::PrepareMessage(std::string_view topic, size_t payload_size, uint8_t memory_block_id)
-{
-	DEBUG_PRINT("Preparing message.");
-
-	Uuid trace_id;
-	Uuid::Generate(&trace_id);
-
-	DEBUG_PRINT("Trace id generated.");
-
-	return PrepareMessage(topic, payload_size, trace_id, memory_block_id);
-}
-
 Message LocalMessageBroker::PrepareMessage(std::string_view topic, size_t payload_size, Uuid trace_id, uint8_t memory_block_id)
 {
 	// Allocate a payload.
@@ -494,53 +482,6 @@ void LocalMessageBroker::PublishMessage(Message &message, bool is_final)
 	message.m_HasBeenPublished = is_final;
 }
 
-void LocalMessageBroker::PublishData(std::string_view topic, const void *data, size_t data_size, uint8_t memory_block_id)
-{
-	Uuid trace_id;
-	Uuid::Generate(&trace_id);
-
-	PublishData(topic, data, data_size, trace_id, memory_block_id);
-}
-
-void LocalMessageBroker::PublishData(std::string_view topic, const void *data, size_t data_size, Uuid trace_id, uint8_t memory_block_id)
-{
-	auto message = PrepareMessage(topic, data_size, trace_id, memory_block_id);
-
-	// Copy the data to the payload.
-	std::memcpy(message.m_Payload, data, data_size);
-
-	// Set the array information.
-	ArrayInfo &array_info = message.m_Header->payload_info.array_info;
-
-	array_info.data_type = 'u';
-	array_info.byte_order = '=';
-	array_info.item_size = 1;
-	array_info.ndim = 1;
-	array_info.shape[0] = data_size;
-	array_info.strides[0] = 1;
-
-	PublishMessage(message);
-}
-
-void LocalMessageBroker::PublishArray(std::string_view topic, const ArrayView &array, uint8_t memory_block_id)
-{
-	Uuid trace_id;
-	Uuid::Generate(&trace_id);
-
-	PublishArray(topic, array, trace_id, memory_block_id);
-}
-
-void LocalMessageBroker::PublishArray(std::string_view topic, const ArrayView &array, Uuid trace_id, uint8_t memory_block_id)
-{
-	auto message = PrepareMessage(topic, array.info.GetSizeInBytes(), trace_id, memory_block_id);
-
-	// Copy over array and array info.
-	std::memcpy(message.m_Payload, array.data, array.info.GetSizeInBytes());
-	message.SetArrayInfo(array.info);
-
-	PublishMessage(message);
-}
-
 std::optional<Message> LocalMessageBroker::TryGetMessage(std::string_view topic, size_t frame_id)
 {
 	auto topic_header = GetTopicHeader(topic);
@@ -562,7 +503,40 @@ Message LocalMessageBroker::FetchMessage(TopicHeader* topic_header, size_t frame
 	return Message(header, payload, true);
 }
 
-std::optional<Message> LocalMessageBroker::GetNewestMessage(std::string_view topic)
+std::uint64_t LocalMessageBroker::GetNextMessageId(TopicHeader *topic_header, size_t last_read_frame_id, MessageSubscriptionMode mode)
+{
+	size_t frame_id = last_read_frame_id + 1;
+	size_t newest_frame_id = topic_header->last_frame_id.load(std::memory_order_relaxed);
+	size_t oldest_frame_id = topic_header->first_frame_id.load(std::memory_order_relaxed);
+
+	if (newest_frame_id != 0)
+		newest_frame_id--;
+
+	switch (m_SubscriptionMode)
+	{
+		case MessageSubscriptionMode::NewestOnly:
+
+		// If the frame we are aiming to read is not the newest,
+		// return the newest frame instead.
+		if (newest_frame_id > frame_id)
+			frame_id = newest_frame_id;
+
+		break;
+
+		case MessageSubscriptionMode::Sequential:
+
+		// If the frame was discarded already,
+		// return the oldest available frame instead.
+		if (frame_id < oldest_frame_id)
+			frame_id = oldest_frame_id;
+
+		break;
+	}
+
+	return frame_id;
+}
+
+std::optional<Message> LocalMessageBroker::GetCurrentMessage(std::string_view topic)
 {
 	auto topic_header = GetTopicHeader(topic);
 
@@ -570,6 +544,36 @@ std::optional<Message> LocalMessageBroker::GetNewestMessage(std::string_view top
 		return std::nullopt;
 
 	auto frame_id = topic_header->last_frame_id - 1;
+
+	return FetchMessage(topic_header, frame_id);
+}
+
+std::optional<Message> LocalMessageBroker::GetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode, double timeout_in_sec, EventWaitMethod wait_type, void (*error_check)())
+{
+	auto topic_header = GetTopicHeader(topic);
+
+	std::uint64_t new_frame_id = GetNextMessageId(topic_header, last_read_frame_id, mode);
+
+	// Check if the frame is available.
+	if (topic_header->IsMessageAvailable(new_frame_id))
+		return FetchMessage(m_TopicHeader, new_frame_id);
+
+	// Otherwise, wait for it.
+	auto lock = EventLockGuard(m_MessageBroker->m_Event);
+	m_MessageBroker->m_Event->Wait(timeout_in_seconds, [this, new_frame_id]() { return m_TopicHeader->last_frame_id > new_frame_id; }, wait_type, error_check);
+
+	return FetchMessage(m_TopicHeader, new_frame_id);
+}
+
+std::optional<Message> LocalMessageBroker::TryGetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode)
+{
+	auto topic_header = GetTopicHeader(topic);
+
+	std::uint64_t frame_id = GetNextMessageId(topic_header, last_read_frame_id, mode);
+
+	// Check if the frame is available.
+	if (!topic_header->IsMessageAvailable(frame_id))
+		return std::nullopt;
 
 	return FetchMessage(topic_header, frame_id);
 }
@@ -638,21 +642,6 @@ std::vector<std::string> LocalMessageBroker::GetAllMessageTopics()
 	return m_TopicHeaders->GetAllKeys();
 }
 
-MessageSubscription LocalMessageBroker::Subscribe(std::string_view topic, MessageSubscriptionMode mode)
-{
-	auto topic_header = GetTopicHeader(topic);
-	auto starting_frame_id = topic_header->first_frame_id.load(std::memory_order_relaxed);
-
-	return MessageSubscription(shared_from_this(), topic_header, starting_frame_id, mode);
-}
-
-MessageSubscription LocalMessageBroker::Subscribe(std::string_view topic, size_t starting_frame_id, MessageSubscriptionMode mode)
-{
-	auto topic_header = GetTopicHeader(topic);
-
-	return MessageSubscription(shared_from_this(), topic_header, starting_frame_id, mode);
-}
-
 std::shared_ptr<Memory> LocalMessageBroker::GetMemory(uint8_t memory_block_id)
 {
 	if (memory_block_id >= m_MemoryBlocks.size())
@@ -698,209 +687,4 @@ TopicHeader *LocalMessageBroker::GetTopicHeader(std::string_view topic)
 	DEBUG_PRINT("Created a topic header!");
 
 	return topic_header;
-}
-
-Message::Message(MessageHeader *header, void *payload, bool has_been_published)
-	: m_Header(header), m_Payload(payload), m_HasBeenPublished(has_been_published)
-{
-}
-
-std::string_view Message::GetTopic() const
-{
-	return m_Header->topic;
-}
-
-const Uuid &Message::GetPayloadId() const
-{
-	return m_Header->payload_id;
-}
-
-std::uint16_t Message::GetPartialFrameId() const
-{
-	return m_Header->partial_frame_id;
-}
-
-const Uuid &Message::GetTraceId() const
-{
-	return m_Header->trace_id;
-}
-
-std::string_view Message::GetProducerHostname() const
-{
-	return m_Header->producer_hostname;
-}
-
-std::uint32_t Message::GetProducerPid() const
-{
-	return m_Header->producer_pid;
-}
-
-std::uint64_t Message::GetProducerTimestamp() const
-{
-	return m_Header->producer_timestamp;
-}
-
-const PayloadInfo &Message::GetPayloadInfo() const
-{
-	return m_Header->payload_info;
-}
-
-const ArrayInfo &Message::GetArrayInfo() const
-{
-	return m_Header->payload_info.array_info;
-}
-
-void Message::SetArrayInfo(const ArrayInfo &array_info)
-{
-	m_Header->payload_info.array_info = array_info;
-}
-
-ArrayView Message::GetPayload() const
-{
-	return {m_Header->payload_info.array_info, m_Payload};
-}
-
-std::size_t Message::GetPayloadSize() const
-{
-	return m_Header->payload_info.total_size;
-}
-
-MetadataEntry *Message::GetMetadataEntry(std::string_view key, bool create_if_not_exists)
-{
-	for (size_t i = 0; i < m_Header->num_metadata_entries; i++)
-		if (key == std::string_view(m_Header->metadata_entries[i].key.data()))
-			return &m_Header->metadata_entries[i];
-
-	if (!create_if_not_exists)
-		return nullptr;
-
-	// Create a new entry.
-	if (m_Header->num_metadata_entries >= MAX_NUM_METADATA_ENTRIES)
-	{
-		throw std::range_error("Metadata entries are full.");
-	}
-
-	auto entry_id = m_Header->num_metadata_entries++;
-	auto entry = &m_Header->metadata_entries[entry_id];
-
-	entry->key.fill('\0');
-	key.copy(entry->key.data(), entry->key.size() - 1);
-
-	return entry;
-}
-
-void Message::SetMetadataEntry(std::string_view key, std::int64_t value)
-{
-	auto entry = GetMetadataEntry(key, true);
-
-	entry->type = MetadataType::Integer;
-	entry->value.integer = value;
-}
-
-void Message::SetMetadataEntry(std::string_view key, double value)
-{
-	auto entry = GetMetadataEntry(key, true);
-
-	entry->type = MetadataType::Integer;
-	entry->value.floating_point = value;
-}
-
-void Message::SetMetadataEntry(std::string_view key, std::string_view value)
-{
-	auto entry = GetMetadataEntry(key, true);
-
-	entry->type = MetadataType::String;
-	entry->value.string.fill('\0');
-	value.copy(entry->value.string.data(), entry->value.string.size() - 1);
-}
-
-const std::uint64_t Message::GetStartByte() const
-{
-	return m_Header->start_byte;
-}
-
-void Message::SetStartByte(std::uint64_t start_byte)
-{
-	m_Header->start_byte = start_byte;
-}
-
-const std::uint64_t Message::GetEndByte() const
-{
-	return m_Header->end_byte;
-}
-
-void Message::SetEndByte(std::uint64_t end_byte)
-{
-	m_Header->end_byte = end_byte;
-}
-
-MessageSubscription::MessageSubscription(std::shared_ptr<LocalMessageBroker> message_broker, TopicHeader *topic_header, std::uint64_t starting_frame_id, MessageSubscriptionMode mode)
-	: m_MessageBroker(message_broker), m_TopicHeader(topic_header), m_NextFrameIdToRead(starting_frame_id), m_SubscriptionMode(mode)
-{
-}
-
-Message MessageSubscription::GetNextMessage(double timeout_in_seconds, EventWaitMethod wait_type, void (*error_check)())
-{
-	std::uint64_t frame_id = GetNextMessageId();
-
-	// Check if the frame is available.
-	if (m_TopicHeader->IsMessageAvailable(frame_id))
-	{
-		m_NextFrameIdToRead = frame_id + 1;
-
-		return m_MessageBroker->FetchMessage(m_TopicHeader, frame_id);
-	}
-
-	// Otherwise, wait for it.
-	m_MessageBroker->m_Event->Wait(timeout_in_seconds, [this, frame_id]() { return m_TopicHeader->last_frame_id > frame_id; }, wait_type, error_check);
-
-	m_NextFrameIdToRead = frame_id + 1;
-
-	return m_MessageBroker->FetchMessage(m_TopicHeader, frame_id);
-}
-
-std::optional<Message> MessageSubscription::TryGetNextMessage()
-{
-	std::uint64_t frame_id = GetNextMessageId();
-
-	// Check if the frame is available.
-	if (!m_TopicHeader->IsMessageAvailable(frame_id))
-		return std::nullopt;
-
-	m_NextFrameIdToRead = frame_id + 1;
-
-	return m_MessageBroker->FetchMessage(m_TopicHeader, frame_id);
-}
-
-std::uint64_t MessageSubscription::GetNextMessageId()
-{
-	size_t frame_id = m_NextFrameIdToRead;
-	size_t newest_frame_id = m_TopicHeader->last_frame_id.load(std::memory_order_relaxed);
-	size_t oldest_frame_id = m_TopicHeader->first_frame_id.load(std::memory_order_relaxed);
-
-	if (newest_frame_id != 0)
-		newest_frame_id--;
-
-	switch (m_SubscriptionMode)
-	{
-		case MessageSubscriptionMode::NewestOnly:
-
-		// If the frame we are aiming to read is not the newest,
-		// return the newest frame instead.
-		if (newest_frame_id > frame_id)
-			frame_id = newest_frame_id;
-
-		break;
-
-		case MessageSubscriptionMode::Sequential:
-
-		// If the frame was discarded already,
-		// return the oldest available frame instead.
-		if (frame_id < oldest_frame_id)
-			frame_id = oldest_frame_id;
-
-		break;
-	}
-
-	return frame_id;
 }

--- a/catkit_core/LocalMessageBroker.cpp
+++ b/catkit_core/LocalMessageBroker.cpp
@@ -344,7 +344,7 @@ Message LocalMessageBroker::PrepareMessage(std::string_view topic, size_t payloa
 
 	DEBUG_PRINT("Header set");
 
-	return Message(header, payload, false);
+	return Message(header, payload, INVALID_FRAME_ID, false);
 }
 
 void LocalMessageBroker::PublishMessage(Message &message, bool is_final)
@@ -500,7 +500,7 @@ Message LocalMessageBroker::FetchMessage(TopicHeader* topic_header, size_t frame
 	auto memory = GetMemory(header->payload_info.memory_block_id);
 	auto payload = memory->GetAddress(offset);
 
-	return Message(header, payload, true);
+	return Message(header, payload, frame_id, true);
 }
 
 std::uint64_t LocalMessageBroker::GetNextMessageId(TopicHeader *topic_header, size_t last_read_frame_id, MessageSubscriptionMode mode)
@@ -512,7 +512,7 @@ std::uint64_t LocalMessageBroker::GetNextMessageId(TopicHeader *topic_header, si
 	if (newest_frame_id != 0)
 		newest_frame_id--;
 
-	switch (m_SubscriptionMode)
+	switch (mode)
 	{
 		case MessageSubscriptionMode::NewestOnly:
 
@@ -548,7 +548,7 @@ std::optional<Message> LocalMessageBroker::GetCurrentMessage(std::string_view to
 	return FetchMessage(topic_header, frame_id);
 }
 
-std::optional<Message> LocalMessageBroker::GetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode, double timeout_in_sec, EventWaitMethod wait_type, void (*error_check)())
+std::optional<Message> LocalMessageBroker::GetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode, double timeout_in_seconds, EventWaitMethod wait_type, void (*error_check)())
 {
 	auto topic_header = GetTopicHeader(topic);
 
@@ -556,13 +556,13 @@ std::optional<Message> LocalMessageBroker::GetNextMessage(std::string_view topic
 
 	// Check if the frame is available.
 	if (topic_header->IsMessageAvailable(new_frame_id))
-		return FetchMessage(m_TopicHeader, new_frame_id);
+		return FetchMessage(topic_header, new_frame_id);
 
 	// Otherwise, wait for it.
-	auto lock = EventLockGuard(m_MessageBroker->m_Event);
-	m_MessageBroker->m_Event->Wait(timeout_in_seconds, [this, new_frame_id]() { return m_TopicHeader->last_frame_id > new_frame_id; }, wait_type, error_check);
+	auto lock = EventLockGuard(m_Event);
+	m_Event->Wait(timeout_in_seconds, [topic_header, new_frame_id]() { return topic_header->last_frame_id > new_frame_id; }, wait_type, error_check);
 
-	return FetchMessage(m_TopicHeader, new_frame_id);
+	return FetchMessage(topic_header, new_frame_id);
 }
 
 std::optional<Message> LocalMessageBroker::TryGetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode)

--- a/catkit_core/LocalMessageBroker.cpp
+++ b/catkit_core/LocalMessageBroker.cpp
@@ -503,9 +503,9 @@ Message LocalMessageBroker::FetchMessage(TopicHeader* topic_header, size_t frame
 	return Message(header, payload, frame_id, true);
 }
 
-std::uint64_t LocalMessageBroker::GetNextMessageId(TopicHeader *topic_header, size_t last_read_frame_id, MessageSubscriptionMode mode)
+std::uint64_t LocalMessageBroker::GetNextMessageId(TopicHeader *topic_header, size_t preferred_next_frame_id, MessageSubscriptionMode mode)
 {
-	size_t frame_id = last_read_frame_id + 1;
+	size_t frame_id = preferred_next_frame_id;
 	size_t newest_frame_id = topic_header->last_frame_id.load(std::memory_order_relaxed);
 	size_t oldest_frame_id = topic_header->first_frame_id.load(std::memory_order_relaxed);
 
@@ -548,11 +548,11 @@ std::optional<Message> LocalMessageBroker::GetCurrentMessage(std::string_view to
 	return FetchMessage(topic_header, frame_id);
 }
 
-std::optional<Message> LocalMessageBroker::GetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode, double timeout_in_seconds, EventWaitMethod wait_type, void (*error_check)())
+std::optional<Message> LocalMessageBroker::GetNextMessage(std::string_view topic, size_t preferred_next_frame_id, MessageSubscriptionMode mode, double timeout_in_seconds, EventWaitMethod wait_type, void (*error_check)())
 {
 	auto topic_header = GetTopicHeader(topic);
 
-	std::uint64_t new_frame_id = GetNextMessageId(topic_header, last_read_frame_id, mode);
+	std::uint64_t new_frame_id = GetNextMessageId(topic_header, preferred_next_frame_id, mode);
 
 	// Check if the frame is available.
 	if (topic_header->IsMessageAvailable(new_frame_id))
@@ -565,11 +565,11 @@ std::optional<Message> LocalMessageBroker::GetNextMessage(std::string_view topic
 	return FetchMessage(topic_header, new_frame_id);
 }
 
-std::optional<Message> LocalMessageBroker::TryGetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode)
+std::optional<Message> LocalMessageBroker::TryGetNextMessage(std::string_view topic, size_t preferred_next_frame_id, MessageSubscriptionMode mode)
 {
 	auto topic_header = GetTopicHeader(topic);
 
-	std::uint64_t frame_id = GetNextMessageId(topic_header, last_read_frame_id, mode);
+	std::uint64_t frame_id = GetNextMessageId(topic_header, preferred_next_frame_id, mode);
 
 	// Check if the frame is available.
 	if (!topic_header->IsMessageAvailable(frame_id))

--- a/catkit_core/LocalMessageBroker.cpp
+++ b/catkit_core/LocalMessageBroker.cpp
@@ -559,7 +559,6 @@ std::optional<Message> LocalMessageBroker::GetNextMessage(std::string_view topic
 		return FetchMessage(topic_header, new_frame_id);
 
 	// Otherwise, wait for it.
-	auto lock = EventLockGuard(m_Event);
 	m_Event->Wait(timeout_in_seconds, [topic_header, new_frame_id]() { return topic_header->last_frame_id > new_frame_id; }, wait_type, error_check);
 
 	return FetchMessage(topic_header, new_frame_id);

--- a/catkit_core/LocalMessageBroker.cpp
+++ b/catkit_core/LocalMessageBroker.cpp
@@ -265,7 +265,7 @@ std::size_t LocalMessageBroker::CalculateBufferSize()
 	return 0;
 }
 
-Message LocalMessageBroker::PrepareMessage(std::string_view topic, size_t payload_size, Uuid trace_id, uint8_t memory_block_id)
+Message LocalMessageBroker::PrepareMessageImpl(std::string_view topic, size_t payload_size, Uuid trace_id, uint8_t memory_block_id)
 {
 	// Allocate a payload.
 	auto allocator = GetAllocator(memory_block_id);

--- a/catkit_core/LocalMessageBroker.cpp
+++ b/catkit_core/LocalMessageBroker.cpp
@@ -1,4 +1,4 @@
-#include "MessageBroker.h"
+#include "LocalMessageBroker.h"
 
 #include "Util.h"
 #include "Timing.h"

--- a/catkit_core/LocalMessageBroker.h
+++ b/catkit_core/LocalMessageBroker.h
@@ -78,7 +78,7 @@ public:
 	static std::size_t CalculateBufferSize(); // TODO: Add parameters.
 
 	// Prepare a message for publishing with a trace ID.
-	virtual Message PrepareMessage(std::string_view topic, size_t payload_size, Uuid trace_id, uint8_t memory_block_id = 0) override;
+	virtual Message PrepareMessageImpl(std::string_view topic, size_t payload_size, Uuid trace_id, uint8_t memory_block_id = 0) override;
 
 	// Publish a message.
 	virtual void PublishMessage(Message &message, bool is_final = true) override;
@@ -87,10 +87,10 @@ public:
 	virtual std::optional<Message> GetCurrentMessage(std::string_view topic) override;
 
 	// Get the next message for a topic.
-	virtual std::optional<Message> GetNextMessage(std::string_view topic, size_t frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly, double timeout_in_seconds = -1, EventWaitMethod wait_type = EventWaitMethod::Default, void (*error_check)() = nullptr) override;
+	virtual std::optional<Message> GetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly, double timeout_in_seconds = -1, EventWaitMethod wait_type = EventWaitMethod::Default, void (*error_check)() = nullptr) override;
 
 	// Try to get the next message for a topic.
-	virtual std::optional<Message> TryGetNextMessage(std::string_view topic, size_t frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly) override;
+	virtual std::optional<Message> TryGetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly) override;
 
 	// Get the message rate for a topic.
 	virtual double GetMessageRate(std::string_view topic) override;

--- a/catkit_core/LocalMessageBroker.h
+++ b/catkit_core/LocalMessageBroker.h
@@ -87,10 +87,10 @@ public:
 	virtual std::optional<Message> GetCurrentMessage(std::string_view topic) override;
 
 	// Get the next message for a topic.
-	virtual std::optional<Message> GetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly, double timeout_in_seconds = -1, EventWaitMethod wait_type = EventWaitMethod::Default, void (*error_check)() = nullptr) override;
+	virtual std::optional<Message> GetNextMessage(std::string_view topic, size_t preferred_next_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly, double timeout_in_seconds = -1, EventWaitMethod wait_type = EventWaitMethod::Default, void (*error_check)() = nullptr) override;
 
 	// Try to get the next message for a topic.
-	virtual std::optional<Message> TryGetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly) override;
+	virtual std::optional<Message> TryGetNextMessage(std::string_view topic, size_t preferred_next_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly) override;
 
 	// Get the message rate for a topic.
 	virtual double GetMessageRate(std::string_view topic) override;
@@ -117,7 +117,7 @@ public:
 
 private:
 	Message FetchMessage(TopicHeader *topic_header, size_t frame_id);
-	std::uint64_t GetNextMessageId(TopicHeader *topic_header, size_t last_read_frame_id, MessageSubscriptionMode mode);
+	std::uint64_t GetNextMessageId(TopicHeader *topic_header, size_t preferred_next_frame_id, MessageSubscriptionMode mode);
 
 	std::shared_ptr<HybridPoolAllocator> GetAllocator(uint8_t memory_block_id);
 	std::shared_ptr<Memory> GetMemory(uint8_t memory_block_id);

--- a/catkit_core/LocalMessageBroker.h
+++ b/catkit_core/LocalMessageBroker.h
@@ -18,74 +18,12 @@
 
 const std::array<std::uint8_t, 4> MESSAGE_BROKER_VERSION = {0, 1, 0, 0};
 
-const size_t VERSION_SIZE = 8;
 const size_t TOPIC_HASH_MAP_SIZE = 16384;
-const size_t TOPIC_MAX_KEY_SIZE = 127;
 const size_t TOPIC_MAX_NUM_MESSAGES = 32;
-const size_t HOST_NAME_SIZE = 64;
-const size_t METADATA_MAX_STRLEN = 8;
-const size_t METADATA_MAX_KEYLEN = 7;
 const size_t MAX_NUM_MESSAGES = 65536;
-const size_t MAX_NUM_METADATA_ENTRIES = 12;
-const size_t MAX_SHARED_MEMORY_ID_SIZE = 64;
 const size_t MAX_NUM_BLOCKS = 8192;
-const size_t MEMORY_ALIGNMENT = 64;
-const size_t MIN_SIZE_POOL = 256 * 256 * 2;
-const size_t NUM_EVENTS_IN_BUFFER = 64;
-
-const std::uint64_t INVALID_FRAME_ID = 0xFFFFFFFFFFFFFFFF;
-
-enum class MetadataType : std::uint8_t
-{
-	Integer,
-	Float,
-	String
-};
-
-union MetadataValue
-{
-	std::int64_t integer;
-	double floating_point;
-	std::array<char, METADATA_MAX_STRLEN> string;
-};
-
-struct MetadataEntry
-{
-	std::array<char, METADATA_MAX_KEYLEN> key;
-	MetadataType type;
-	MetadataValue value;
-};
-
-struct PayloadInfo
-{
-	std::uint8_t memory_block_id;
-	HybridPoolAllocator::Handle block_handle;
-	std::uint64_t offset_in_buffer;
-	std::uint64_t total_size;
-
-	ArrayInfo array_info;
-};
-
-struct MessageHeader
-{
-	char topic[TOPIC_MAX_KEY_SIZE];
-
-	Uuid payload_id;
-	Uuid trace_id;
-
-	char producer_hostname[HOST_NAME_SIZE];
-	std::uint32_t producer_pid;
-	std::uint64_t producer_timestamp;
-
-	PayloadInfo payload_info;
-	std::uint64_t start_byte;
-	std::uint64_t end_byte;
-
-	std::uint16_t partial_frame_id;
-
-	std::uint8_t num_metadata_entries;
-	MetadataEntry metadata_entries[MAX_NUM_METADATA_ENTRIES];
-};
+const size_t MEMORY_ALIGNMENT = 32;
+const size_t MIN_SIZE_POOL = 1024;
 
 struct TopicHeader
 {
@@ -145,14 +83,23 @@ public:
 	// Publish a message.
 	virtual void PublishMessage(Message &message, bool is_final = true) override;
 
-	// Try to get a message by topic and frame ID.
-	std::optional<Message> TryGetMessage(std::string_view topic, size_t frame_id);
-
 	// Get the newest message for a topic.
 	virtual std::optional<Message> GetCurrentMessage(std::string_view topic) override;
 
 	// Get the next message for a topic.
 	virtual std::optional<Message> GetNextMessage(std::string_view topic, size_t frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly, double timeout_in_seconds = -1, EventWaitMethod wait_type = EventWaitMethod::Default, void (*error_check)() = nullptr) override;
+
+	// Try to get the next message for a topic.
+	virtual std::optional<Message> TryGetNextMessage(std::string_view topic, size_t frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly) override;
+
+	// Get the message rate for a topic.
+	virtual double GetMessageRate(std::string_view topic) override;
+
+	// Get the message topics for all messages in this broker.
+	virtual std::vector<std::string> GetAllMessageTopics() override;
+
+	// Try to get a message by topic and frame ID.
+	std::optional<Message> TryGetMessage(std::string_view topic, size_t frame_id);
 
 	// Check for message availability.
 	bool IsMessageAvailable(std::string_view topic, size_t frame_id);
@@ -165,12 +112,6 @@ public:
 
 	// Get the oldest message ID for a topic.
 	size_t GetOldestMessageId(std::string_view topic);
-
-	// Get the message rate for a topic.
-	virtual double GetMessageRate(std::string_view topic) override;
-
-	// Get the message topics for all messages in this broker.
-	virtual std::vector<std::string> GetAllMessageTopics() override;
 
 	ShareableType GetType() const override;
 

--- a/catkit_core/LocalMessageBroker.h
+++ b/catkit_core/LocalMessageBroker.h
@@ -1,5 +1,5 @@
-#ifndef MESSAGE_BROKER_H
-#define MESSAGE_BROKER_H
+#ifndef LOCAL_MESSAGE_BROKER_H
+#define LOCAL_MESSAGE_BROKER_H
 
 #include "HashMap.h"
 #include "Event.h"
@@ -287,4 +287,4 @@ private:
 	std::vector<std::shared_ptr<Memory>> m_MemoryBlocks;
 };
 
-#endif // MESSAGE_BROKER_H
+#endif // LOCAL_MESSAGE_BROKER_H

--- a/catkit_core/LocalMessageBroker.h
+++ b/catkit_core/LocalMessageBroker.h
@@ -10,6 +10,7 @@
 #include "CudaSharedMemory.h"
 #include "Uuid.h"
 #include "ArrayView.h"
+#include "MessageBroker.h"
 
 #include <memory>
 #include <array>
@@ -117,82 +118,7 @@ struct MessageBrokerHeader
 	MessageHeader message_headers[MAX_NUM_MESSAGES];
 };
 
-class LocalMessageBroker;
-
-class Message
-{
-	friend class LocalMessageBroker;
-
-private:
-	Message(MessageHeader *header, void *payload, bool has_been_published = false);
-
-public:
-	std::string_view GetTopic() const;
-
-	const Uuid &GetPayloadId() const;
-	std::uint16_t GetPartialFrameId() const;
-
-	const Uuid &GetTraceId() const;
-
-	std::string_view GetProducerHostname() const;
-	std::uint32_t GetProducerPid() const;
-	std::uint64_t GetProducerTimestamp() const;
-
-	const PayloadInfo &GetPayloadInfo() const;
-
-	const ArrayInfo &GetArrayInfo() const;
-	void SetArrayInfo(const ArrayInfo &array_info);
-
-	ArrayView GetPayload() const;
-	std::size_t GetPayloadSize() const;
-
-	MetadataEntry *GetMetadataEntry(std::string_view key, bool create_if_not_exists = false);
-	void SetMetadataEntry(std::string_view key, std::int64_t value);
-	void SetMetadataEntry(std::string_view key, double value);
-	void SetMetadataEntry(std::string_view key, std::string_view value);
-
-	const std::uint64_t GetStartByte() const;
-	void SetStartByte(std::uint64_t start_byte);
-
-	const std::uint64_t GetEndByte() const;
-	void SetEndByte(std::uint64_t end_byte);
-
-private:
-	MessageHeader *m_Header;
-	void *m_Payload;
-
-	bool m_HasBeenPublished;
-};
-
-enum class MessageSubscriptionMode
-{
-	// Only the latest messages are processed, skipping older ones
-	NewestOnly,
-	// Messages are processed in order without skipping
-	Sequential,
-};
-
-class MessageSubscription
-{
-	friend class LocalMessageBroker;
-
-public:
-	Message GetNextMessage(double timeout_in_seconds = -1, EventWaitMethod wait_type = EventWaitMethod::Default, void (*error_check)() = nullptr);
-	std::optional<Message> TryGetNextMessage();
-
-	std::uint64_t GetNextMessageId();
-
-private:
-	MessageSubscription(std::shared_ptr<LocalMessageBroker>, TopicHeader *topic_header, std::uint64_t starting_frame_id, MessageSubscriptionMode mode);
-
-	std::shared_ptr<LocalMessageBroker> m_MessageBroker;
-	TopicHeader *m_TopicHeader;
-
-	std::uint64_t m_NextFrameIdToRead;
-	MessageSubscriptionMode m_SubscriptionMode;
-};
-
-class LocalMessageBroker : public Shareable, public std::enable_shared_from_this<LocalMessageBroker>
+class LocalMessageBroker : public Shareable, public MessageBroker
 {
 	friend class MessageSubscription;
 
@@ -213,32 +139,20 @@ public:
 
 	static std::size_t CalculateBufferSize(); // TODO: Add parameters.
 
-	// Prepare a message for publishing.
-	Message PrepareMessage(std::string_view topic, size_t payload_size, uint8_t memory_block_id = 0);
-
 	// Prepare a message for publishing with a trace ID.
-	Message PrepareMessage(std::string_view topic, size_t payload_size, Uuid trace_id, uint8_t memory_block_id = 0);
+	virtual Message PrepareMessage(std::string_view topic, size_t payload_size, Uuid trace_id, uint8_t memory_block_id = 0) override;
 
 	// Publish a message.
-	void PublishMessage(Message &message, bool is_final = true);
-
-	// Convenience function for publishing data.
-	void PublishData(std::string_view topic, const void *data, size_t data_size, uint8_t memory_block_id = 0);
-
-	// Convenience function for publishing data with a trace ID.
-	void PublishData(std::string_view topic, const void *data, size_t data_size, Uuid trace_id, uint8_t memory_block_id = 0);
-
-	// Convenience function for publishing an array.
-	void PublishArray(std::string_view topic, const ArrayView &array, uint8_t memory_block_id = 0);
-
-	// Convenience function for publishing an array with a trace ID.
-	void PublishArray(std::string_view topic, const ArrayView &array, Uuid trace_id, uint8_t memory_block_id = 0);
+	virtual void PublishMessage(Message &message, bool is_final = true) override;
 
 	// Try to get a message by topic and frame ID.
 	std::optional<Message> TryGetMessage(std::string_view topic, size_t frame_id);
 
 	// Get the newest message for a topic.
-	std::optional<Message> GetNewestMessage(std::string_view topic);
+	virtual std::optional<Message> GetCurrentMessage(std::string_view topic) override;
+
+	// Get the next message for a topic.
+	virtual std::optional<Message> GetNextMessage(std::string_view topic, size_t frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly, double timeout_in_seconds = -1, EventWaitMethod wait_type = EventWaitMethod::Default, void (*error_check)() = nullptr) override;
 
 	// Check for message availability.
 	bool IsMessageAvailable(std::string_view topic, size_t frame_id);
@@ -253,21 +167,16 @@ public:
 	size_t GetOldestMessageId(std::string_view topic);
 
 	// Get the message rate for a topic.
-	double GetMessageRate(std::string_view topic);
+	virtual double GetMessageRate(std::string_view topic) override;
 
 	// Get the message topics for all messages in this broker.
-	std::vector<std::string> GetAllMessageTopics();
-
-	// Subscribe to a topic for receiving messages.
-	MessageSubscription Subscribe(std::string_view topic, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly);
-
-	// Subscribe to a topic for receiving messages with a starting frame ID.
-	MessageSubscription Subscribe(std::string_view topic, size_t starting_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly);
+	virtual std::vector<std::string> GetAllMessageTopics() override;
 
 	ShareableType GetType() const override;
 
 private:
 	Message FetchMessage(TopicHeader *topic_header, size_t frame_id);
+	std::uint64_t GetNextMessageId(TopicHeader *topic_header, size_t last_read_frame_id, MessageSubscriptionMode mode);
 
 	std::shared_ptr<HybridPoolAllocator> GetAllocator(uint8_t memory_block_id);
 	std::shared_ptr<Memory> GetMemory(uint8_t memory_block_id);

--- a/catkit_core/MessageBroker.cpp
+++ b/catkit_core/MessageBroker.cpp
@@ -215,10 +215,21 @@ void MessageBroker::PublishData(std::string_view topic, const void *data, size_t
 
 void MessageBroker::PublishArray(std::string_view topic, ArrayView array, uint8_t memory_block_id)
 {
+	Uuid trace_id;
+	Uuid::Generate(&trace_id);
+
+	PublishArray(topic, array, trace_id, memory_block_id);
 }
 
 void MessageBroker::PublishArray(std::string_view topic, ArrayView array, Uuid trace_id, uint8_t memory_block_id)
 {
+	auto message = PrepareMessage(topic, array.info.GetSizeInBytes(), trace_id, memory_block_id);
+
+	// Copy over array and array info.
+	std::memcpy(message.m_Payload, array.data, array.info.GetSizeInBytes());
+	message.SetArrayInfo(array.info);
+
+	PublishMessage(message);
 }
 
 MessageSubscription MessageBroker::Subscribe(std::string_view topic, MessageSubscriptionMode mode)

--- a/catkit_core/MessageBroker.cpp
+++ b/catkit_core/MessageBroker.cpp
@@ -141,33 +141,33 @@ void Message::SetEndByte(std::uint64_t end_byte)
 	m_Header->end_byte = end_byte;
 }
 
-MessageSubscription::MessageSubscription(std::shared_ptr<MessageBroker> message_broker, std::string_view topic, std::uint64_t last_read_frame_id, MessageSubscriptionMode mode)
-	: m_MessageBroker(message_broker), m_Topic(topic), m_LastReadFrameId(last_read_frame_id), m_SubscriptionMode(mode)
+MessageSubscription::MessageSubscription(std::shared_ptr<MessageBroker> message_broker, std::string_view topic, std::uint64_t preferred_next_frame_id, MessageSubscriptionMode mode)
+	: m_MessageBroker(message_broker), m_Topic(topic), m_PreferredNextFrameId(preferred_next_frame_id), m_SubscriptionMode(mode)
 {
 }
 
 std::optional<Message> MessageSubscription::GetNextMessage(double timeout_in_seconds, EventWaitMethod wait_type, void (*error_check)())
 {
-	auto message = m_MessageBroker->GetNextMessage(m_Topic, m_LastReadFrameId, m_SubscriptionMode, timeout_in_seconds, wait_type, error_check);
+	auto message = m_MessageBroker->GetNextMessage(m_Topic, m_PreferredNextFrameId, m_SubscriptionMode, timeout_in_seconds, wait_type, error_check);
 
 	if (!message.has_value())
 		return message;
 
 	// We are going to return a message. Update our frame id for the next call.
-	m_LastReadFrameId = message->GetFrameId() + 1;
+	m_PreferredNextFrameId = message->GetFrameId() + 1;
 
 	return message;
 }
 
 std::optional<Message> MessageSubscription::TryGetNextMessage()
 {
-	auto message = m_MessageBroker->TryGetNextMessage(m_Topic, m_LastReadFrameId, m_SubscriptionMode);
+	auto message = m_MessageBroker->TryGetNextMessage(m_Topic, m_PreferredNextFrameId, m_SubscriptionMode);
 
 	if (!message.has_value())
 		return message;
 
 	// We are going to return a message. Update our frame id for the next call.
-	m_LastReadFrameId = message->GetFrameId() + 1;
+	m_PreferredNextFrameId = message->GetFrameId() + 1;
 
 	return message;
 }
@@ -229,7 +229,7 @@ MessageSubscription MessageBroker::Subscribe(std::string_view topic, MessageSubs
 	return Subscribe(topic, starting_frame_id, mode);
 }
 
-MessageSubscription MessageBroker::Subscribe(std::string_view topic, size_t starting_frame_id, MessageSubscriptionMode mode)
+MessageSubscription MessageBroker::Subscribe(std::string_view topic, size_t preferred_next_frame_id, MessageSubscriptionMode mode)
 {
-	return MessageSubscription(shared_from_this(), topic, starting_frame_id, mode);
+	return MessageSubscription(shared_from_this(), topic, preferred_next_frame_id, mode);
 }

--- a/catkit_core/MessageBroker.cpp
+++ b/catkit_core/MessageBroker.cpp
@@ -1,0 +1,232 @@
+#include "MessageBroker.h"
+
+#include "LocalMessageBroker.h"
+
+Message::Message(MessageHeader *header, void *payload, bool has_been_published)
+	: m_Header(header), m_Payload(payload), m_HasBeenPublished(has_been_published)
+{
+}
+
+std::string_view Message::GetTopic() const
+{
+	return m_Header->topic;
+}
+
+const Uuid &Message::GetPayloadId() const
+{
+	return m_Header->payload_id;
+}
+
+std::uint16_t Message::GetPartialFrameId() const
+{
+	return m_Header->partial_frame_id;
+}
+
+const Uuid &Message::GetTraceId() const
+{
+	return m_Header->trace_id;
+}
+
+std::string_view Message::GetProducerHostname() const
+{
+	return m_Header->producer_hostname;
+}
+
+std::uint32_t Message::GetProducerPid() const
+{
+	return m_Header->producer_pid;
+}
+
+std::uint64_t Message::GetProducerTimestamp() const
+{
+	return m_Header->producer_timestamp;
+}
+
+const PayloadInfo &Message::GetPayloadInfo() const
+{
+	return m_Header->payload_info;
+}
+
+const ArrayInfo &Message::GetArrayInfo() const
+{
+	return m_Header->payload_info.array_info;
+}
+
+void Message::SetArrayInfo(const ArrayInfo &array_info)
+{
+	m_Header->payload_info.array_info = array_info;
+}
+
+void *Message::GetPayload() const
+{
+	return m_Payload;
+}
+
+std::size_t Message::GetPayloadSize() const
+{
+	return m_Header->payload_info.total_size;
+}
+
+MetadataEntry *Message::GetMetadataEntry(std::string_view key, bool create_if_not_exists)
+{
+	for (size_t i = 0; i < m_Header->num_metadata_entries; i++)
+		if (key == std::string_view(m_Header->metadata_entries[i].key.data()))
+			return &m_Header->metadata_entries[i];
+
+	if (!create_if_not_exists)
+		return nullptr;
+
+	// Create a new entry.
+	if (m_Header->num_metadata_entries >= MAX_NUM_METADATA_ENTRIES)
+	{
+		throw std::range_error("Metadata entries are full.");
+	}
+
+	auto entry_id = m_Header->num_metadata_entries++;
+	auto entry = &m_Header->metadata_entries[entry_id];
+
+	entry->key.fill('\0');
+	key.copy(entry->key.data(), entry->key.size() - 1);
+
+	return entry;
+}
+
+void Message::SetMetadataEntry(std::string_view key, std::int64_t value)
+{
+	auto entry = GetMetadataEntry(key, true);
+
+	entry->type = MetadataType::Integer;
+	entry->value.integer = value;
+}
+
+void Message::SetMetadataEntry(std::string_view key, double value)
+{
+	auto entry = GetMetadataEntry(key, true);
+
+	entry->type = MetadataType::Integer;
+	entry->value.floating_point = value;
+}
+
+void Message::SetMetadataEntry(std::string_view key, std::string_view value)
+{
+	auto entry = GetMetadataEntry(key, true);
+
+	entry->type = MetadataType::String;
+	entry->value.string.fill('\0');
+	value.copy(entry->value.string.data(), entry->value.string.size() - 1);
+}
+
+const std::uint64_t Message::GetStartByte() const
+{
+	return m_Header->start_byte;
+}
+
+void Message::SetStartByte(std::uint64_t start_byte)
+{
+	m_Header->start_byte = start_byte;
+}
+
+const std::uint64_t Message::GetEndByte() const
+{
+	return m_Header->end_byte;
+}
+
+void Message::SetEndByte(std::uint64_t end_byte)
+{
+	m_Header->end_byte = end_byte;
+}
+
+MessageSubscription::MessageSubscription(std::shared_ptr<MessageBroker> message_broker, std::string_view topic, std::uint64_t last_read_frame_id, MessageSubscriptionMode mode)
+	: m_MessageBroker(message_broker), m_Topic(topic), m_LastReadFrameId(last_read_frame_id), m_SubscriptionMode(mode)
+{
+}
+
+std::optional<Message> MessageSubscription::GetNextMessage(double timeout_in_seconds, EventWaitMethod wait_type, void (*error_check)())
+{
+	auto message = m_MessageBroker->GetNextMessage(m_Topic, m_LastReadFrameId, m_SubscriptionMode, timeout_in_seconds, wait_type, error_check);
+
+	if (!message.has_value())
+		return message;
+
+	// We are going to return a message. Update our message Id for the next call.
+	m_LastReadFrameId = ...
+}
+
+std::optional<Message> MessageSubscription::TryGetNextMessage()
+{
+	auto message = m_MessageBroker->TryGetNextMessage(m_Topic, m_LastReadFrameId, m_SubscriptionMode);
+
+	if (!message.has_value())
+		return message;
+
+	// We are going to return a message. Update our message Id for the next call.
+	m_LastReadFrameId = ...
+
+}
+
+std::size_t ArrayInfo::GetNumItems() const
+{
+	std::size_t num_items = 1;
+
+	for (std::size_t i = 0; i < ndim; ++i)
+	{
+		num_items *= shape[i];
+	}
+
+	return num_items;
+}
+
+std::size_t ArrayInfo::GetNumBytes() const
+{
+	std::size_t num_items = GetNumItems();
+	return num_items * item_size;
+}
+
+Message MessageBroker::PrepareMessage(std::string_view topic, size_t payload_size, uint8_t memory_block_id)
+{
+	Uuid trace_id;
+	Uuid::Generate(&trace_id);
+
+	return PrepareMessage(topic, payload_size, trace_id, memory_block_id);
+}
+
+void MessageBroker::PublishData(std::string_view topic, const void *data, size_t data_size, uint8_t memory_block_id)
+{
+	Uuid trace_id;
+	Uuid::Generate(&trace_id);
+
+	PublishData(topic, data, data_size, trace_id, memory_block_id);
+}
+
+void MessageBroker::PublishData(std::string_view topic, const void *data, size_t data_size, Uuid trace_id, uint8_t memory_block_id)
+{
+	auto message = PrepareMessage(topic, data_size, trace_id, memory_block_id);
+
+	// Copy the data to the payload.
+	std::memcpy(message.m_Payload, data, data_size);
+
+	// Set the array information.
+	ArrayInfo &array_info = message.m_Header->payload_info.array_info;
+
+	array_info.data_type = 'u';
+	array_info.byte_order = '=';
+	array_info.item_size = 1;
+	array_info.ndim = 1;
+	array_info.shape[0] = data_size;
+	array_info.strides[0] = 1;
+
+	PublishMessage(message);
+}
+
+MessageSubscription MessageBroker::Subscribe(std::string_view topic, MessageSubscriptionMode mode)
+{
+	auto current_message = GetCurrentMessage(topic);
+	auto starting_frame_id = current_message.has_value() ? current_message->m_Header->frame_id : 0;
+
+	return Subscribe(topic, starting_frame_id, mode);
+}
+
+MessageSubscription MessageBroker::Subscribe(std::string_view topic, size_t starting_frame_id, MessageSubscriptionMode mode)
+{
+	return MessageSubscription(shared_from_this(), starting_frame_id, mode);
+}

--- a/catkit_core/MessageBroker.cpp
+++ b/catkit_core/MessageBroker.cpp
@@ -177,7 +177,12 @@ Message MessageBroker::PrepareMessage(std::string_view topic, size_t payload_siz
 	Uuid trace_id;
 	Uuid::Generate(&trace_id);
 
-	return PrepareMessage(topic, payload_size, trace_id, memory_block_id);
+	return PrepareMessageImpl(topic, payload_size, trace_id, memory_block_id);
+}
+
+Message MessageBroker::PrepareMessage(std::string_view topic, size_t payload_size, Uuid trace_id, uint8_t memory_block_id)
+{
+	return PrepareMessageImpl(topic, payload_size, trace_id, memory_block_id);
 }
 
 void MessageBroker::PublishData(std::string_view topic, const void *data, size_t data_size, uint8_t memory_block_id)
@@ -206,6 +211,14 @@ void MessageBroker::PublishData(std::string_view topic, const void *data, size_t
 	array_info.strides[0] = 1;
 
 	PublishMessage(message);
+}
+
+void MessageBroker::PublishArray(std::string_view topic, ArrayView array, uint8_t memory_block_id)
+{
+}
+
+void MessageBroker::PublishArray(std::string_view topic, ArrayView array, Uuid trace_id, uint8_t memory_block_id)
+{
 }
 
 MessageSubscription MessageBroker::Subscribe(std::string_view topic, MessageSubscriptionMode mode)

--- a/catkit_core/MessageBroker.cpp
+++ b/catkit_core/MessageBroker.cpp
@@ -2,8 +2,8 @@
 
 #include "LocalMessageBroker.h"
 
-Message::Message(MessageHeader *header, void *payload, bool has_been_published)
-	: m_Header(header), m_Payload(payload), m_HasBeenPublished(has_been_published)
+Message::Message(MessageHeader *header, void *payload, std::uint64_t frame_id, bool has_been_published)
+	: m_Header(header), m_Payload(payload), m_FrameId(frame_id), m_HasBeenPublished(has_been_published)
 {
 }
 
@@ -15,6 +15,11 @@ std::string_view Message::GetTopic() const
 const Uuid &Message::GetPayloadId() const
 {
 	return m_Header->payload_id;
+}
+
+std::uint64_t Message::GetFrameId() const
+{
+	return m_FrameId;
 }
 
 std::uint16_t Message::GetPartialFrameId() const
@@ -57,9 +62,9 @@ void Message::SetArrayInfo(const ArrayInfo &array_info)
 	m_Header->payload_info.array_info = array_info;
 }
 
-void *Message::GetPayload() const
+ArrayView Message::GetPayload() const
 {
-	return m_Payload;
+	return {m_Header->payload_info.array_info, m_Payload};
 }
 
 std::size_t Message::GetPayloadSize() const
@@ -148,8 +153,10 @@ std::optional<Message> MessageSubscription::GetNextMessage(double timeout_in_sec
 	if (!message.has_value())
 		return message;
 
-	// We are going to return a message. Update our message Id for the next call.
-	m_LastReadFrameId = ...
+	// We are going to return a message. Update our frame id for the next call.
+	m_LastReadFrameId = message->GetFrameId() + 1;
+
+	return message;
 }
 
 std::optional<Message> MessageSubscription::TryGetNextMessage()
@@ -159,27 +166,10 @@ std::optional<Message> MessageSubscription::TryGetNextMessage()
 	if (!message.has_value())
 		return message;
 
-	// We are going to return a message. Update our message Id for the next call.
-	m_LastReadFrameId = ...
+	// We are going to return a message. Update our frame id for the next call.
+	m_LastReadFrameId = message->GetFrameId() + 1;
 
-}
-
-std::size_t ArrayInfo::GetNumItems() const
-{
-	std::size_t num_items = 1;
-
-	for (std::size_t i = 0; i < ndim; ++i)
-	{
-		num_items *= shape[i];
-	}
-
-	return num_items;
-}
-
-std::size_t ArrayInfo::GetNumBytes() const
-{
-	std::size_t num_items = GetNumItems();
-	return num_items * item_size;
+	return message;
 }
 
 Message MessageBroker::PrepareMessage(std::string_view topic, size_t payload_size, uint8_t memory_block_id)
@@ -221,12 +211,12 @@ void MessageBroker::PublishData(std::string_view topic, const void *data, size_t
 MessageSubscription MessageBroker::Subscribe(std::string_view topic, MessageSubscriptionMode mode)
 {
 	auto current_message = GetCurrentMessage(topic);
-	auto starting_frame_id = current_message.has_value() ? current_message->m_Header->frame_id : 0;
+	auto starting_frame_id = current_message.has_value() ? current_message->GetFrameId() : 0;
 
 	return Subscribe(topic, starting_frame_id, mode);
 }
 
 MessageSubscription MessageBroker::Subscribe(std::string_view topic, size_t starting_frame_id, MessageSubscriptionMode mode)
 {
-	return MessageSubscription(shared_from_this(), starting_frame_id, mode);
+	return MessageSubscription(shared_from_this(), topic, starting_frame_id, mode);
 }

--- a/catkit_core/MessageBroker.cpp
+++ b/catkit_core/MessageBroker.cpp
@@ -1,5 +1,7 @@
 #include "MessageBroker.h"
 
+#include <cstring>
+
 #include "LocalMessageBroker.h"
 
 Message::Message(MessageHeader *header, void *payload, std::uint64_t frame_id, bool has_been_published)

--- a/catkit_core/MessageBroker.cpp
+++ b/catkit_core/MessageBroker.cpp
@@ -141,7 +141,7 @@ std::size_t TopicHeader::GetNewestMessageId()
 	return last - 1;
 }
 
-MessageBroker::MessageBroker(
+LocalMessageBroker::LocalMessageBroker(
 	MessageBrokerHeader *header,
 	std::shared_ptr<HashMap> topic_headers,
 	std::shared_ptr<PoolAllocator> message_header_allocator,
@@ -161,7 +161,7 @@ MessageBroker::MessageBroker(
 {
 }
 
-std::shared_ptr<MessageBroker> MessageBroker::Create(StructStream &stream, std::vector<std::shared_ptr<Memory>> memory_blocks)
+std::shared_ptr<LocalMessageBroker> LocalMessageBroker::Create(StructStream &stream, std::vector<std::shared_ptr<Memory>> memory_blocks)
 {
 	DEBUG_PRINT("Creating message broker");
 
@@ -206,7 +206,7 @@ std::shared_ptr<MessageBroker> MessageBroker::Create(StructStream &stream, std::
 
 	DEBUG_PRINT("Creating object.");
 
-	return std::shared_ptr<MessageBroker>(new MessageBroker(
+	return std::shared_ptr<LocalMessageBroker>(new LocalMessageBroker(
 		header,
 		std::move(topic_headers),
 		std::move(message_header_allocator),
@@ -217,7 +217,7 @@ std::shared_ptr<MessageBroker> MessageBroker::Create(StructStream &stream, std::
 	));
 }
 
-std::shared_ptr<MessageBroker> MessageBroker::Open(StructStream &stream)
+std::shared_ptr<LocalMessageBroker> LocalMessageBroker::Open(StructStream &stream)
 {
 	CheckVersion(stream, MESSAGE_BROKER_VERSION);
 
@@ -249,7 +249,7 @@ std::shared_ptr<MessageBroker> MessageBroker::Open(StructStream &stream)
 		}
 	}
 
-	return std::shared_ptr<MessageBroker>(new MessageBroker(
+	return std::shared_ptr<LocalMessageBroker>(new LocalMessageBroker(
 		header,
 		std::move(topic_headers),
 		std::move(message_header_allocator),
@@ -260,12 +260,12 @@ std::shared_ptr<MessageBroker> MessageBroker::Open(StructStream &stream)
 	));
 }
 
-std::size_t MessageBroker::CalculateBufferSize()
+std::size_t LocalMessageBroker::CalculateBufferSize()
 {
 	return 0;
 }
 
-Message MessageBroker::PrepareMessage(std::string_view topic, size_t payload_size, uint8_t memory_block_id)
+Message LocalMessageBroker::PrepareMessage(std::string_view topic, size_t payload_size, uint8_t memory_block_id)
 {
 	DEBUG_PRINT("Preparing message.");
 
@@ -277,7 +277,7 @@ Message MessageBroker::PrepareMessage(std::string_view topic, size_t payload_siz
 	return PrepareMessage(topic, payload_size, trace_id, memory_block_id);
 }
 
-Message MessageBroker::PrepareMessage(std::string_view topic, size_t payload_size, Uuid trace_id, uint8_t memory_block_id)
+Message LocalMessageBroker::PrepareMessage(std::string_view topic, size_t payload_size, Uuid trace_id, uint8_t memory_block_id)
 {
 	// Allocate a payload.
 	auto allocator = GetAllocator(memory_block_id);
@@ -359,7 +359,7 @@ Message MessageBroker::PrepareMessage(std::string_view topic, size_t payload_siz
 	return Message(header, payload, false);
 }
 
-void MessageBroker::PublishMessage(Message &message, bool is_final)
+void LocalMessageBroker::PublishMessage(Message &message, bool is_final)
 {
 	DEBUG_PRINT("Publishing message.");
 
@@ -494,7 +494,7 @@ void MessageBroker::PublishMessage(Message &message, bool is_final)
 	message.m_HasBeenPublished = is_final;
 }
 
-void MessageBroker::PublishData(std::string_view topic, const void *data, size_t data_size, uint8_t memory_block_id)
+void LocalMessageBroker::PublishData(std::string_view topic, const void *data, size_t data_size, uint8_t memory_block_id)
 {
 	Uuid trace_id;
 	Uuid::Generate(&trace_id);
@@ -502,7 +502,7 @@ void MessageBroker::PublishData(std::string_view topic, const void *data, size_t
 	PublishData(topic, data, data_size, trace_id, memory_block_id);
 }
 
-void MessageBroker::PublishData(std::string_view topic, const void *data, size_t data_size, Uuid trace_id, uint8_t memory_block_id)
+void LocalMessageBroker::PublishData(std::string_view topic, const void *data, size_t data_size, Uuid trace_id, uint8_t memory_block_id)
 {
 	auto message = PrepareMessage(topic, data_size, trace_id, memory_block_id);
 
@@ -522,7 +522,7 @@ void MessageBroker::PublishData(std::string_view topic, const void *data, size_t
 	PublishMessage(message);
 }
 
-void MessageBroker::PublishArray(std::string_view topic, const ArrayView &array, uint8_t memory_block_id)
+void LocalMessageBroker::PublishArray(std::string_view topic, const ArrayView &array, uint8_t memory_block_id)
 {
 	Uuid trace_id;
 	Uuid::Generate(&trace_id);
@@ -530,7 +530,7 @@ void MessageBroker::PublishArray(std::string_view topic, const ArrayView &array,
 	PublishArray(topic, array, trace_id, memory_block_id);
 }
 
-void MessageBroker::PublishArray(std::string_view topic, const ArrayView &array, Uuid trace_id, uint8_t memory_block_id)
+void LocalMessageBroker::PublishArray(std::string_view topic, const ArrayView &array, Uuid trace_id, uint8_t memory_block_id)
 {
 	auto message = PrepareMessage(topic, array.info.GetSizeInBytes(), trace_id, memory_block_id);
 
@@ -541,7 +541,7 @@ void MessageBroker::PublishArray(std::string_view topic, const ArrayView &array,
 	PublishMessage(message);
 }
 
-std::optional<Message> MessageBroker::TryGetMessage(std::string_view topic, size_t frame_id)
+std::optional<Message> LocalMessageBroker::TryGetMessage(std::string_view topic, size_t frame_id)
 {
 	auto topic_header = GetTopicHeader(topic);
 
@@ -551,7 +551,7 @@ std::optional<Message> MessageBroker::TryGetMessage(std::string_view topic, size
 	return FetchMessage(topic_header, frame_id);
 }
 
-Message MessageBroker::FetchMessage(TopicHeader* topic_header, size_t frame_id)
+Message LocalMessageBroker::FetchMessage(TopicHeader* topic_header, size_t frame_id)
 {
 	// Assume that the frame is available.
 	auto header = &m_MessageHeaders[topic_header->message_headers[frame_id % TOPIC_MAX_NUM_MESSAGES]];
@@ -562,7 +562,7 @@ Message MessageBroker::FetchMessage(TopicHeader* topic_header, size_t frame_id)
 	return Message(header, payload, true);
 }
 
-std::optional<Message> MessageBroker::GetNewestMessage(std::string_view topic)
+std::optional<Message> LocalMessageBroker::GetNewestMessage(std::string_view topic)
 {
 	auto topic_header = GetTopicHeader(topic);
 
@@ -574,12 +574,12 @@ std::optional<Message> MessageBroker::GetNewestMessage(std::string_view topic)
 	return FetchMessage(topic_header, frame_id);
 }
 
-ShareableType MessageBroker::GetType() const
+ShareableType LocalMessageBroker::GetType() const
 {
-	return ShareableType::MessageBroker;
+	return ShareableType::LocalMessageBroker;
 }
 
-std::shared_ptr<HybridPoolAllocator> MessageBroker::GetAllocator(uint8_t memory_block_id)
+std::shared_ptr<HybridPoolAllocator> LocalMessageBroker::GetAllocator(uint8_t memory_block_id)
 {
 	if (memory_block_id >= m_Allocators.size())
 	{
@@ -589,35 +589,35 @@ std::shared_ptr<HybridPoolAllocator> MessageBroker::GetAllocator(uint8_t memory_
 	return m_Allocators[memory_block_id];
 }
 
-bool MessageBroker::IsMessageAvailable(std::string_view topic, size_t frame_id)
+bool LocalMessageBroker::IsMessageAvailable(std::string_view topic, size_t frame_id)
 {
 	auto topic_header = GetTopicHeader(topic);
 
 	return topic_header->IsMessageAvailable(frame_id);
 }
 
-bool MessageBroker::WillMessageBeAvailable(std::string_view topic, size_t frame_id)
+bool LocalMessageBroker::WillMessageBeAvailable(std::string_view topic, size_t frame_id)
 {
 	auto topic_header = GetTopicHeader(topic);
 
 	return topic_header->WillMessageBeAvailable(frame_id);
 }
 
-size_t MessageBroker::GetNewestMessageId(std::string_view topic)
+size_t LocalMessageBroker::GetNewestMessageId(std::string_view topic)
 {
 	auto topic_header = GetTopicHeader(topic);
 
 	return topic_header->GetNewestMessageId();
 }
 
-size_t MessageBroker::GetOldestMessageId(std::string_view topic)
+size_t LocalMessageBroker::GetOldestMessageId(std::string_view topic)
 {
 	auto topic_header = GetTopicHeader(topic);
 
 	return topic_header->GetOldestMessageId();
 }
 
-double MessageBroker::GetMessageRate(std::string_view topic)
+double LocalMessageBroker::GetMessageRate(std::string_view topic)
 {
 	auto topic_header = GetTopicHeader(topic);
 	auto last_message_header_id = topic_header->message_headers[(topic_header->last_frame_id - 1) % TOPIC_MAX_NUM_MESSAGES];
@@ -633,12 +633,12 @@ double MessageBroker::GetMessageRate(std::string_view topic)
 	return topic_header->frame_rate * std::exp(-FRAMERATE_DECAY * time_delta);
 }
 
-std::vector<std::string> MessageBroker::GetAllMessageTopics()
+std::vector<std::string> LocalMessageBroker::GetAllMessageTopics()
 {
 	return m_TopicHeaders->GetAllKeys();
 }
 
-MessageSubscription MessageBroker::Subscribe(std::string_view topic, MessageSubscriptionMode mode)
+MessageSubscription LocalMessageBroker::Subscribe(std::string_view topic, MessageSubscriptionMode mode)
 {
 	auto topic_header = GetTopicHeader(topic);
 	auto starting_frame_id = topic_header->first_frame_id.load(std::memory_order_relaxed);
@@ -646,14 +646,14 @@ MessageSubscription MessageBroker::Subscribe(std::string_view topic, MessageSubs
 	return MessageSubscription(shared_from_this(), topic_header, starting_frame_id, mode);
 }
 
-MessageSubscription MessageBroker::Subscribe(std::string_view topic, size_t starting_frame_id, MessageSubscriptionMode mode)
+MessageSubscription LocalMessageBroker::Subscribe(std::string_view topic, size_t starting_frame_id, MessageSubscriptionMode mode)
 {
 	auto topic_header = GetTopicHeader(topic);
 
 	return MessageSubscription(shared_from_this(), topic_header, starting_frame_id, mode);
 }
 
-std::shared_ptr<Memory> MessageBroker::GetMemory(uint8_t memory_block_id)
+std::shared_ptr<Memory> LocalMessageBroker::GetMemory(uint8_t memory_block_id)
 {
 	if (memory_block_id >= m_MemoryBlocks.size())
 	{
@@ -663,7 +663,7 @@ std::shared_ptr<Memory> MessageBroker::GetMemory(uint8_t memory_block_id)
 	return m_MemoryBlocks[memory_block_id];
 }
 
-TopicHeader *MessageBroker::GetTopicHeader(std::string_view topic)
+TopicHeader *LocalMessageBroker::GetTopicHeader(std::string_view topic)
 {
 	DEBUG_PRINT("Getting a topic header for " << topic);
 
@@ -834,7 +834,7 @@ void Message::SetEndByte(std::uint64_t end_byte)
 	m_Header->end_byte = end_byte;
 }
 
-MessageSubscription::MessageSubscription(std::shared_ptr<MessageBroker> message_broker, TopicHeader *topic_header, std::uint64_t starting_frame_id, MessageSubscriptionMode mode)
+MessageSubscription::MessageSubscription(std::shared_ptr<LocalMessageBroker> message_broker, TopicHeader *topic_header, std::uint64_t starting_frame_id, MessageSubscriptionMode mode)
 	: m_MessageBroker(message_broker), m_TopicHeader(topic_header), m_NextFrameIdToRead(starting_frame_id), m_SubscriptionMode(mode)
 {
 }

--- a/catkit_core/MessageBroker.h
+++ b/catkit_core/MessageBroker.h
@@ -1,0 +1,193 @@
+#ifndef MESSAGE_BROKER_H
+#define MESSAGE_BROKER_H
+
+#include "HybridPoolAllocator.h"
+#include "Uuid.h"
+#include "Event.h"
+
+#include <cstdint>
+#include <cstddef>
+#include <array>
+#include <atomic>
+#include <string_view>
+#include <string>
+#include <optional>
+
+const size_t TOPIC_HASH_MAP_SIZE = 16384;
+const size_t TOPIC_MAX_KEY_SIZE = 127;
+const size_t TOPIC_MAX_NUM_MESSAGES = 32;
+const size_t HOST_NAME_SIZE = 64;
+const size_t METADATA_MAX_STRLEN = 8;
+const size_t METADATA_MAX_KEYLEN = 7;
+const size_t MAX_NUM_MESSAGES = 65536;
+const size_t MAX_NUM_DIMENSIONS = 4;
+const size_t MAX_NUM_METADATA_ENTRIES = 12;
+const size_t MAX_SHARED_MEMORY_ID_SIZE = 64;
+const size_t MAX_NUM_BLOCKS = 8192;
+const size_t MEMORY_ALIGNMENT = 32;
+const size_t MIN_SIZE_POOL = 1024;
+const size_t NUM_EVENTS_IN_BUFFER = 64;
+
+const std::uint64_t INVALID_FRAME_ID = 0xFFFFFFFFFFFFFFFF;
+
+enum class MetadataType : std::uint8_t
+{
+	Integer,
+	Float,
+	String
+};
+
+union MetadataValue
+{
+	std::int64_t integer;
+	double floating_point;
+	std::array<char, METADATA_MAX_STRLEN> string;
+};
+
+struct MetadataEntry
+{
+	std::array<char, METADATA_MAX_KEYLEN> key;
+	MetadataType type;
+	MetadataValue value;
+};
+
+struct ArrayInfo
+{
+	char data_type;
+	char byte_order;
+	std::uint8_t item_size;
+	std::uint8_t ndim;
+	std::uint32_t shape[MAX_NUM_DIMENSIONS];
+	std::uint32_t strides[MAX_NUM_DIMENSIONS];
+
+	std::size_t GetNumItems() const;
+	std::size_t GetNumBytes() const;
+};
+
+struct PayloadInfo
+{
+	std::uint8_t memory_block_id;
+	HybridPoolAllocator::Handle block_handle;
+	std::uint64_t offset_in_buffer;
+	std::uint64_t total_size;
+
+	ArrayInfo array_info;
+};
+
+struct MessageHeader
+{
+	char topic[TOPIC_MAX_KEY_SIZE];
+
+	Uuid payload_id;
+	Uuid trace_id;
+
+	char producer_hostname[HOST_NAME_SIZE];
+	std::uint32_t producer_pid;
+	std::uint64_t producer_timestamp;
+
+	PayloadInfo payload_info;
+	std::uint64_t start_byte;
+	std::uint64_t end_byte;
+
+	std::uint16_t partial_frame_id;
+
+	std::uint8_t num_metadata_entries;
+	MetadataEntry metadata_entries[MAX_NUM_METADATA_ENTRIES];
+};
+
+class LocalMessageBroker;
+
+class Message
+{
+	friend class LocalMessageBroker;
+
+private:
+	Message(MessageHeader *header, void *payload, bool has_been_published = false);
+
+public:
+	std::string_view GetTopic() const;
+
+	const Uuid &GetPayloadId() const;
+	std::uint16_t GetPartialFrameId() const;
+
+	const Uuid &GetTraceId() const;
+
+	std::string_view GetProducerHostname() const;
+	std::uint32_t GetProducerPid() const;
+	std::uint64_t GetProducerTimestamp() const;
+
+	const PayloadInfo &GetPayloadInfo() const;
+
+	const ArrayInfo &GetArrayInfo() const;
+	void SetArrayInfo(const ArrayInfo &array_info);
+
+	void *GetPayload() const;
+	std::size_t GetPayloadSize() const;
+
+	MetadataEntry *GetMetadataEntry(std::string_view key, bool create_if_not_exists = false);
+	void SetMetadataEntry(std::string_view key, std::int64_t value);
+	void SetMetadataEntry(std::string_view key, double value);
+	void SetMetadataEntry(std::string_view key, std::string_view value);
+
+	const std::uint64_t GetStartByte() const;
+	void SetStartByte(std::uint64_t start_byte);
+
+	const std::uint64_t GetEndByte() const;
+	void SetEndByte(std::uint64_t end_byte);
+
+private:
+	MessageHeader *m_Header;
+	void *m_Payload;
+
+	bool m_HasBeenPublished;
+};
+
+enum class MessageSubscriptionMode
+{
+	// Only the latest messages are processed, skipping older ones
+	NewestOnly,
+	// Messages are processed in order without skipping
+	Sequential,
+};
+
+class MessageSubscription
+{
+	friend class MessageBroker;
+
+public:
+	std::optional<Message> GetNextMessage(double timeout_in_seconds = -1, EventWaitMethod wait_type = EventWaitMethod::Default, void (*error_check)() = nullptr);
+	std::optional<Message> TryGetNextMessage();
+
+private:
+	MessageSubscription(std::shared_ptr<MessageBroker> broker, std::string_view topic, std::uint64_t last_read_frame_id, MessageSubscriptionMode mode);
+
+	std::shared_ptr<MessageBroker> m_MessageBroker;
+
+	std::string m_Topic;
+	std::uint64_t m_LastReadFrameId;
+	MessageSubscriptionMode m_SubscriptionMode;
+};
+
+class MessageBroker : public std::enable_shared_from_this<MessageBroker>
+{
+public:
+	Message PrepareMessage(std::string_view topic, size_t payload_size, uint8_t memory_block_id = 0);
+	virtual Message PrepareMessage(std::string_view topic, size_t payload_size, Uuid trace_id, uint8_t memory_block_id = 0) = 0;
+
+	virtual void PublishMessage(Message &message, bool is_final = true) = 0;
+
+	void PublishData(std::string_view topic, const void *data, size_t data_size, uint8_t memory_block_id = 0);
+	void PublishData(std::string_view topic, const void *data, size_t data_size, Uuid trace_id, uint8_t memory_block_id = 0);
+
+	virtual std::optional<Message> GetCurrentMessage(std::string_view topic) = 0;
+	virtual std::optional<Message> GetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly, double timeout_in_seconds = -1, EventWaitMethod wait_type = EventWaitMethod::Default, void (*error_check)() = nullptr) = 0;
+	virtual std::optional<Message> TryGetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly);
+
+	MessageSubscription Subscribe(std::string_view topic, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly);
+	MessageSubscription Subscribe(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly);
+
+	virtual std::vector<std::string> GetAllMessageTopics() = 0;
+	virtual double GetMessageRate(std::string_view topic) = 0;
+};
+
+#endif // MESSAGE_BROKER_H

--- a/catkit_core/MessageBroker.h
+++ b/catkit_core/MessageBroker.h
@@ -117,11 +117,11 @@ struct MessageBrokerHeader
 	MessageHeader message_headers[MAX_NUM_MESSAGES];
 };
 
-class MessageBroker;
+class LocalMessageBroker;
 
 class Message
 {
-	friend class MessageBroker;
+	friend class LocalMessageBroker;
 
 private:
 	Message(MessageHeader *header, void *payload, bool has_been_published = false);
@@ -174,7 +174,7 @@ enum class MessageSubscriptionMode
 
 class MessageSubscription
 {
-	friend class MessageBroker;
+	friend class LocalMessageBroker;
 
 public:
 	Message GetNextMessage(double timeout_in_seconds = -1, EventWaitMethod wait_type = EventWaitMethod::Default, void (*error_check)() = nullptr);
@@ -183,21 +183,21 @@ public:
 	std::uint64_t GetNextMessageId();
 
 private:
-	MessageSubscription(std::shared_ptr<MessageBroker>, TopicHeader *topic_header, std::uint64_t starting_frame_id, MessageSubscriptionMode mode);
+	MessageSubscription(std::shared_ptr<LocalMessageBroker>, TopicHeader *topic_header, std::uint64_t starting_frame_id, MessageSubscriptionMode mode);
 
-	std::shared_ptr<MessageBroker> m_MessageBroker;
+	std::shared_ptr<LocalMessageBroker> m_MessageBroker;
 	TopicHeader *m_TopicHeader;
 
 	std::uint64_t m_NextFrameIdToRead;
 	MessageSubscriptionMode m_SubscriptionMode;
 };
 
-class MessageBroker : public Shareable, public std::enable_shared_from_this<MessageBroker>
+class LocalMessageBroker : public Shareable, public std::enable_shared_from_this<LocalMessageBroker>
 {
 	friend class MessageSubscription;
 
 private:
-	MessageBroker(
+	LocalMessageBroker(
 		MessageBrokerHeader *header,
 		std::shared_ptr<HashMap> topic_headers,
 		std::shared_ptr<PoolAllocator> message_header_allocator,
@@ -208,8 +208,8 @@ private:
 	);
 
 public:
-	static std::shared_ptr<MessageBroker> Create(StructStream &stream, std::vector<std::shared_ptr<Memory>> memory_blocks);
-	static std::shared_ptr<MessageBroker> Open(StructStream &stream);
+	static std::shared_ptr<LocalMessageBroker> Create(StructStream &stream, std::vector<std::shared_ptr<Memory>> memory_blocks);
+	static std::shared_ptr<LocalMessageBroker> Open(StructStream &stream);
 
 	static std::size_t CalculateBufferSize(); // TODO: Add parameters.
 

--- a/catkit_core/MessageBroker.h
+++ b/catkit_core/MessageBroker.h
@@ -4,6 +4,7 @@
 #include "HybridPoolAllocator.h"
 #include "Uuid.h"
 #include "Event.h"
+#include "ArrayView.h"
 
 #include <cstdint>
 #include <cstddef>
@@ -13,20 +14,11 @@
 #include <string>
 #include <optional>
 
-const size_t TOPIC_HASH_MAP_SIZE = 16384;
 const size_t TOPIC_MAX_KEY_SIZE = 127;
-const size_t TOPIC_MAX_NUM_MESSAGES = 32;
 const size_t HOST_NAME_SIZE = 64;
 const size_t METADATA_MAX_STRLEN = 8;
 const size_t METADATA_MAX_KEYLEN = 7;
-const size_t MAX_NUM_MESSAGES = 65536;
-const size_t MAX_NUM_DIMENSIONS = 4;
 const size_t MAX_NUM_METADATA_ENTRIES = 12;
-const size_t MAX_SHARED_MEMORY_ID_SIZE = 64;
-const size_t MAX_NUM_BLOCKS = 8192;
-const size_t MEMORY_ALIGNMENT = 32;
-const size_t MIN_SIZE_POOL = 1024;
-const size_t NUM_EVENTS_IN_BUFFER = 64;
 
 const std::uint64_t INVALID_FRAME_ID = 0xFFFFFFFFFFFFFFFF;
 
@@ -49,19 +41,6 @@ struct MetadataEntry
 	std::array<char, METADATA_MAX_KEYLEN> key;
 	MetadataType type;
 	MetadataValue value;
-};
-
-struct ArrayInfo
-{
-	char data_type;
-	char byte_order;
-	std::uint8_t item_size;
-	std::uint8_t ndim;
-	std::uint32_t shape[MAX_NUM_DIMENSIONS];
-	std::uint32_t strides[MAX_NUM_DIMENSIONS];
-
-	std::size_t GetNumItems() const;
-	std::size_t GetNumBytes() const;
 };
 
 struct PayloadInfo
@@ -100,14 +79,16 @@ class LocalMessageBroker;
 class Message
 {
 	friend class LocalMessageBroker;
+	friend class MessageBroker;
 
 private:
-	Message(MessageHeader *header, void *payload, bool has_been_published = false);
+	Message(MessageHeader *header, void *payload, std::uint64_t frame_id, bool has_been_published = false);
 
 public:
 	std::string_view GetTopic() const;
 
 	const Uuid &GetPayloadId() const;
+	std::uint64_t GetFrameId() const;
 	std::uint16_t GetPartialFrameId() const;
 
 	const Uuid &GetTraceId() const;
@@ -121,7 +102,7 @@ public:
 	const ArrayInfo &GetArrayInfo() const;
 	void SetArrayInfo(const ArrayInfo &array_info);
 
-	void *GetPayload() const;
+	ArrayView GetPayload() const;
 	std::size_t GetPayloadSize() const;
 
 	MetadataEntry *GetMetadataEntry(std::string_view key, bool create_if_not_exists = false);
@@ -139,6 +120,7 @@ private:
 	MessageHeader *m_Header;
 	void *m_Payload;
 
+	std::uint64_t m_FrameId;
 	bool m_HasBeenPublished;
 };
 
@@ -171,23 +153,22 @@ private:
 class MessageBroker : public std::enable_shared_from_this<MessageBroker>
 {
 public:
-	Message PrepareMessage(std::string_view topic, size_t payload_size, uint8_t memory_block_id = 0);
 	virtual Message PrepareMessage(std::string_view topic, size_t payload_size, Uuid trace_id, uint8_t memory_block_id = 0) = 0;
-
 	virtual void PublishMessage(Message &message, bool is_final = true) = 0;
-
-	void PublishData(std::string_view topic, const void *data, size_t data_size, uint8_t memory_block_id = 0);
-	void PublishData(std::string_view topic, const void *data, size_t data_size, Uuid trace_id, uint8_t memory_block_id = 0);
 
 	virtual std::optional<Message> GetCurrentMessage(std::string_view topic) = 0;
 	virtual std::optional<Message> GetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly, double timeout_in_seconds = -1, EventWaitMethod wait_type = EventWaitMethod::Default, void (*error_check)() = nullptr) = 0;
 	virtual std::optional<Message> TryGetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly);
 
-	MessageSubscription Subscribe(std::string_view topic, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly);
-	MessageSubscription Subscribe(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly);
-
 	virtual std::vector<std::string> GetAllMessageTopics() = 0;
 	virtual double GetMessageRate(std::string_view topic) = 0;
+
+	Message PrepareMessage(std::string_view topic, size_t payload_size, uint8_t memory_block_id = 0);
+	void PublishData(std::string_view topic, const void *data, size_t data_size, uint8_t memory_block_id = 0);
+	void PublishData(std::string_view topic, const void *data, size_t data_size, Uuid trace_id, uint8_t memory_block_id = 0);
+
+	MessageSubscription Subscribe(std::string_view topic, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly);
+	MessageSubscription Subscribe(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly);
 };
 
 #endif // MESSAGE_BROKER_H

--- a/catkit_core/MessageBroker.h
+++ b/catkit_core/MessageBroker.h
@@ -141,12 +141,12 @@ public:
 	std::optional<Message> TryGetNextMessage();
 
 private:
-	MessageSubscription(std::shared_ptr<MessageBroker> broker, std::string_view topic, std::uint64_t last_read_frame_id, MessageSubscriptionMode mode);
+	MessageSubscription(std::shared_ptr<MessageBroker> broker, std::string_view topic, std::uint64_t preferred_next_frame_id, MessageSubscriptionMode mode);
 
 	std::shared_ptr<MessageBroker> m_MessageBroker;
 
 	std::string m_Topic;
-	std::uint64_t m_LastReadFrameId;
+	std::uint64_t m_PreferredNextFrameId;
 	MessageSubscriptionMode m_SubscriptionMode;
 };
 
@@ -157,8 +157,8 @@ public:
 	virtual void PublishMessage(Message &message, bool is_final = true) = 0;
 
 	virtual std::optional<Message> GetCurrentMessage(std::string_view topic) = 0;
-	virtual std::optional<Message> GetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly, double timeout_in_seconds = -1, EventWaitMethod wait_type = EventWaitMethod::Default, void (*error_check)() = nullptr) = 0;
-	virtual std::optional<Message> TryGetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly) = 0;
+	virtual std::optional<Message> GetNextMessage(std::string_view topic, size_t preferred_next_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly, double timeout_in_seconds = -1, EventWaitMethod wait_type = EventWaitMethod::Default, void (*error_check)() = nullptr) = 0;
+	virtual std::optional<Message> TryGetNextMessage(std::string_view topic, size_t preferred_next_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly) = 0;
 
 	virtual std::vector<std::string> GetAllMessageTopics() = 0;
 	virtual double GetMessageRate(std::string_view topic) = 0;
@@ -173,7 +173,7 @@ public:
 	void PublishArray(std::string_view topic, ArrayView array, Uuid trace_id, uint8_t memory_block_id = 0);
 
 	MessageSubscription Subscribe(std::string_view topic, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly);
-	MessageSubscription Subscribe(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly);
+	MessageSubscription Subscribe(std::string_view topic, size_t preferred_next_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly);
 };
 
 #endif // MESSAGE_BROKER_H

--- a/catkit_core/MessageBroker.h
+++ b/catkit_core/MessageBroker.h
@@ -153,19 +153,24 @@ private:
 class MessageBroker : public std::enable_shared_from_this<MessageBroker>
 {
 public:
-	virtual Message PrepareMessage(std::string_view topic, size_t payload_size, Uuid trace_id, uint8_t memory_block_id = 0) = 0;
+	virtual Message PrepareMessageImpl(std::string_view topic, size_t payload_size, Uuid trace_id, uint8_t memory_block_id = 0) = 0;
 	virtual void PublishMessage(Message &message, bool is_final = true) = 0;
 
 	virtual std::optional<Message> GetCurrentMessage(std::string_view topic) = 0;
 	virtual std::optional<Message> GetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly, double timeout_in_seconds = -1, EventWaitMethod wait_type = EventWaitMethod::Default, void (*error_check)() = nullptr) = 0;
-	virtual std::optional<Message> TryGetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly);
+	virtual std::optional<Message> TryGetNextMessage(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly) = 0;
 
 	virtual std::vector<std::string> GetAllMessageTopics() = 0;
 	virtual double GetMessageRate(std::string_view topic) = 0;
 
 	Message PrepareMessage(std::string_view topic, size_t payload_size, uint8_t memory_block_id = 0);
+	Message PrepareMessage(std::string_view topic, size_t payload_size, Uuid trace_id, uint8_t memory_block_id = 0);
+
 	void PublishData(std::string_view topic, const void *data, size_t data_size, uint8_t memory_block_id = 0);
 	void PublishData(std::string_view topic, const void *data, size_t data_size, Uuid trace_id, uint8_t memory_block_id = 0);
+
+	void PublishArray(std::string_view topic, ArrayView array, uint8_t memory_block_id = 0);
+	void PublishArray(std::string_view topic, ArrayView array, Uuid trace_id, uint8_t memory_block_id = 0);
 
 	MessageSubscription Subscribe(std::string_view topic, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly);
 	MessageSubscription Subscribe(std::string_view topic, size_t last_read_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly);

--- a/catkit_core/MessageBroker.h
+++ b/catkit_core/MessageBroker.h
@@ -74,6 +74,7 @@ struct MessageHeader
 	MetadataEntry metadata_entries[MAX_NUM_METADATA_ENTRIES];
 };
 
+class MessageBroker;
 class LocalMessageBroker;
 
 class Message

--- a/catkit_core/Shareable.cpp
+++ b/catkit_core/Shareable.cpp
@@ -35,8 +35,8 @@ std::shared_ptr<Shareable> Shareable::Open(StructStream &stream)
 		return LocalMemory::Open(stream);
 	case ShareableType::HashMap:
 		return HashMap::Open(stream);
-	case ShareableType::MessageBroker:
-		return MessageBroker::Open(stream);
+	case ShareableType::LocalMessageBroker:
+		return LocalMessageBroker::Open(stream);
 	case ShareableType::BuddyAllocator:
 		return BuddyAllocator::Open(stream);
 	case ShareableType::HybridPoolAllocator:

--- a/catkit_core/Shareable.cpp
+++ b/catkit_core/Shareable.cpp
@@ -8,7 +8,7 @@
 #include "SharedMemory.h"
 #include "LocalMemory.h"
 #include "HashMap.h"
-#include "MessageBroker.h"
+#include "LocalMessageBroker.h"
 #include "BuddyAllocator.h"
 #include "HybridPoolAllocator.h"
 

--- a/catkit_core/Shareable.h
+++ b/catkit_core/Shareable.h
@@ -15,7 +15,7 @@ enum class ShareableType
 	PoolAllocator,
 	SharedMemory,
 	HashMap,
-	MessageBroker,
+	LocalMessageBroker,
 	BuddyAllocator,
 	HybridPoolAllocator
 };

--- a/catkit_core/TestbedProxy.cpp
+++ b/catkit_core/TestbedProxy.cpp
@@ -2,6 +2,7 @@
 
 #include "Timing.h"
 #include "HostName.h"
+#include "LocalMessageBroker.h"
 #include "testbed.pb.h"
 
 #include <memory>
@@ -382,7 +383,7 @@ void TestbedProxy::GetTestbedInfo()
 
 	m_MessageBrokerHeader = SharedMemory::Open(reply.message_broker_id());
 	StructStream stream = StructStream(m_MessageBrokerHeader);
-	m_MessageBroker = MessageBroker::Open(stream);
+	m_MessageBroker = LocalMessageBroker::Open(stream);
 
 	m_LoggingIngressPort = reply.logging_ingress_port();
 	m_LoggingEgressPort = reply.logging_egress_port();

--- a/tests/test_message_broker.py
+++ b/tests/test_message_broker.py
@@ -89,14 +89,14 @@ def test_message_broker_publish_array(broker):
     arr = np.random.randn(10)
     broker.publish_array('test_array', arr)
 
-    msg = broker.get_newest_message('test_array')
+    msg = broker.get_current_message('test_array')
     assert np.array_equal(msg.payload, arr)
 
 def test_message_broker_publish_data(broker):
     data = b'abcd'
     broker.publish_data('test_data', data)
 
-    msg = broker.get_newest_message('test_data')
+    msg = broker.get_current_message('test_data')
     assert msg.payload.data == data
     assert msg.payload.dtype == 'uint8'
 

--- a/tests/test_message_broker.py
+++ b/tests/test_message_broker.py
@@ -29,33 +29,44 @@ def test_message_subscription(broker):
         message.payload = arr
         broker.publish_message(message)
 
-    message_1 = subscription_newest.get_next_message(0.01)
-    message_2 = subscription_sequential.get_next_message(0.01)
-    message_3 = subscription_sequential.get_next_message(0.01)
-
-    assert message_1 is not None
-    assert message_2 is not None
-    assert message_3 is not None
-
-    assert message_1.frame_id == 2
-    assert message_2.frame_id == 0
-
-    assert message_1.payload[0] == 12
-    assert message_2.payload[0] == 10
-    assert message_3.payload[0] == 11
-
-    assert subscription_newest.try_get_next_message() is None
-
-    m = subscription_sequential.try_get_next_message()
+    # The first message from a NewestOnly subscription should skip all non-current messages.
+    m = subscription_newest.get_next_message(0.01)
     assert m is not None
+    assert m.frame_id == 2
     assert m.payload[0] == 12
 
-    assert subscription_sequential.try_get_next_message() is None
+    # Getting a next message from this subscription should return None, since there are no more messages.
+    with pytest.raises(RuntimeError, match="Waiting time has expired."):
+        subscription_newest.get_next_message(0.01)
 
+    # The first message from a Sequential subscription should not skip any messages.
+    m = subscription_sequential.get_next_message(0.01)
+    assert m is not None
+    assert m.frame_id == 0
+    assert m.payload[0] == 10
+
+    # Same for the second message.
+    m = subscription_sequential.get_next_message(0.01)
+    assert m is not None
+    assert m.frame_id == 1
+    assert m.payload[0] == 11
+
+    # Same for the third message.
+    m = subscription_sequential.get_next_message(0.01)
+    assert m is not None
+    assert m.frame_id == 2
+    assert m.payload[0] == 12
+
+    # Getting a next message from this subscription should return None, since there are only three messages.
+    with pytest.raises(RuntimeError, match="Waiting time has expired."):
+        subscription_sequential.get_next_message(0.01)
+
+    # Creating a NewestOnly subscription starting at ID 1 should return the newest message (ID 2).
     subscription_newest2 = broker.subscribe(topic, preferred_next_frame_id=1, mode=MessageSubscriptionMode.NewestOnly)
     m = subscription_newest2.get_next_message(0.01)
     assert m.frame_id == 2
 
+    # A Sequential subscription starting at ID 1 should return the second message (ID 1).
     subscription_sequential2 = broker.subscribe(topic, preferred_next_frame_id=1, mode=MessageSubscriptionMode.Sequential)
     m = subscription_sequential2.get_next_message(0.01)
     assert m.frame_id == 1

--- a/tests/test_message_broker.py
+++ b/tests/test_message_broker.py
@@ -1,4 +1,4 @@
-from catkit2.catkit_bindings import LocalMemory, MessageBroker, MessageSubscriptionMode
+from catkit2.catkit_bindings import LocalMemory, LocalMessageBroker, MessageSubscriptionMode
 import numpy as np
 import pytest
 
@@ -14,7 +14,7 @@ def header_memory():
 def broker(header_memory):
     block = LocalMemory.create(1024 * 1024 * 1024)
 
-    broker = MessageBroker.create(header_memory, [block])
+    broker = LocalMessageBroker.create(header_memory, [block])
     yield broker
 
 def test_message_subscription(broker):
@@ -29,9 +29,6 @@ def test_message_subscription(broker):
         message.payload = arr
         broker.publish_message(message)
 
-    assert subscription_newest.next_message_id == 2
-    assert subscription_sequential.next_message_id == 0
-
     message_1 = subscription_newest.get_next_message(0.01)
     message_2 = subscription_sequential.get_next_message(0.01)
     message_3 = subscription_sequential.get_next_message(0.01)
@@ -39,6 +36,9 @@ def test_message_subscription(broker):
     assert message_1 is not None
     assert message_2 is not None
     assert message_3 is not None
+
+    assert message_1.frame_id == 2
+    assert message_2.frame_id == 0
 
     assert message_1.payload[0] == 12
     assert message_2.payload[0] == 10
@@ -52,11 +52,13 @@ def test_message_subscription(broker):
 
     assert subscription_sequential.try_get_next_message() is None
 
-    subscription_newest2 = broker.subscribe(topic, starting_frame_id=1, mode=MessageSubscriptionMode.NewestOnly)
-    assert subscription_newest2.next_message_id == 2
+    subscription_newest2 = broker.subscribe(topic, preferred_next_frame_id=1, mode=MessageSubscriptionMode.NewestOnly)
+    m = subscription_newest2.get_next_message(0.01)
+    assert m.frame_id == 2
 
-    subscription_sequential2 = broker.subscribe(topic, starting_frame_id=1, mode=MessageSubscriptionMode.Sequential)
-    assert subscription_sequential2.next_message_id == 1
+    subscription_sequential2 = broker.subscribe(topic, preferred_next_frame_id=1, mode=MessageSubscriptionMode.Sequential)
+    m = subscription_sequential2.get_next_message(0.01)
+    assert m.frame_id == 1
 
 dtypes = ['int8', 'uint8', 'int16', 'uint16', 'int32', 'uint32', 'int64', 'uint64', 'float32', 'float64', 'complex64', 'complex128']
 shapes = [[10], [10, 10], [10, 10, 10], [10, 10, 10, 10]]
@@ -72,7 +74,7 @@ def test_message_dtype_and_shape(broker, shape, dtype):
     message.payload = arr
     broker.publish_message(message)
 
-    retrieved_message = broker.get_newest_message(topic)
+    retrieved_message = broker.get_current_message(topic)
 
     assert np.all(arr == retrieved_message.payload)
     assert retrieved_message.payload.dtype == dtype
@@ -105,7 +107,7 @@ def test_message_broker_publish(broker):
 
     broker.publish_data(topic, data)
 
-    retrieved_message = broker.get_newest_message(topic)
+    retrieved_message = broker.get_current_message(topic)
 
     assert (retrieved_message.payload == arr).all()
 
@@ -114,14 +116,14 @@ def test_message_broker_trace_id(broker):
     data = b'hello world'
 
     broker.publish_data(topic, data)
-    message_1 = broker.get_newest_message(topic)
+    message_1 = broker.get_current_message(topic)
 
     broker.publish_data(topic, data * 2)
-    message_2 = broker.get_newest_message(topic)
+    message_2 = broker.get_current_message(topic)
 
     assert str(message_2.trace_id) != str(message_1.trace_id)
 
     broker.publish_data(topic, data * 3, trace_id=message_1.trace_id)
-    message_3 = broker.get_newest_message(topic)
+    message_3 = broker.get_current_message(topic)
 
     assert str(message_3.trace_id) == str(message_1.trace_id)


### PR DESCRIPTION
> [!CAUTION]
> This PR requires #331 to be merged before.

Since we're gonna have multiple message brokers, this PR creates a base class `MessageBroker` that contains the interface for all message brokers. All message brokers share the `Message` and `MessageSubscription` structs and their functionality.

This also renames the existing `MessageBroker` class into `LocalMessageBroker`.

FYI: this looks like a lot of code changes, but it's mainly moving code around rather than creating new code or modifying existing code.