### PR TITLE
Add dark data stream to power meter

### DIFF
--- a/catkit2/services/thorlabs_pm/thorlabs_pm.py
+++ b/catkit2/services/thorlabs_pm/thorlabs_pm.py
@@ -16,9 +16,7 @@ class ThorlabsPM(Service):
         self.interval = self.config.get('interval', 10)
 
         self.power = self.make_data_stream('power', 'float64', [1], 20)
-
         self.dark = self.make_data_stream('power', 'float64', [1], 20)
-        self.dark.submit_data(np.array([0.], dtype='float64'))
 
     def main(self):
         while not self.should_shut_down:

--- a/catkit2/services/thorlabs_pm/thorlabs_pm.py
+++ b/catkit2/services/thorlabs_pm/thorlabs_pm.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from catkit2.testbed.service import Service
 
+
 class ThorlabsPM(Service):
     _BUFFER_SIZE = 256
 
@@ -124,6 +125,7 @@ class ThorlabsPM(Service):
                 pass  # Don't do anything with this.
 
             self.instrument = ctypes.c_void_p(None)
+
 
 if __name__ == '__main__':
     service = ThorlabsPM()

--- a/catkit2/services/thorlabs_pm/thorlabs_pm.py
+++ b/catkit2/services/thorlabs_pm/thorlabs_pm.py
@@ -17,7 +17,7 @@ class ThorlabsPM(Service):
         self.interval = self.config.get('interval', 10)
 
         self.power = self.make_data_stream('power', 'float64', [1], 20)
-        self.dark = self.make_data_stream('power', 'float64', [1], 20)
+        self.dark = self.make_data_stream('dark', 'float64', [1], 20)
 
     def main(self):
         while not self.should_shut_down:

--- a/catkit2/services/thorlabs_pm/thorlabs_pm.py
+++ b/catkit2/services/thorlabs_pm/thorlabs_pm.py
@@ -17,6 +17,9 @@ class ThorlabsPM(Service):
 
         self.power = self.make_data_stream('power', 'float64', [1], 20)
 
+        self.dark = self.make_data_stream('power', 'float64', [1], 20)
+        self.dark.submit_data(np.array([0.], dtype='float64'))
+
     def main(self):
         while not self.should_shut_down:
             power = self.get_power()

--- a/catkit2/services/thorlabs_pm_sim/thorlabs_pm_sim.py
+++ b/catkit2/services/thorlabs_pm_sim/thorlabs_pm_sim.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from catkit2.testbed.service import Service
 
+
 class ThorlabsPMSim(Service):
     def __init__(self):
         super().__init__('thorlabs_pm_sim')
@@ -23,6 +24,7 @@ class ThorlabsPMSim(Service):
 
     def get_power(self):
         return 1  # Watt
+
 
 if __name__ == '__main__':
     service = ThorlabsPMSim()

--- a/catkit2/services/thorlabs_pm_sim/thorlabs_pm_sim.py
+++ b/catkit2/services/thorlabs_pm_sim/thorlabs_pm_sim.py
@@ -9,9 +9,7 @@ class ThorlabsPMSim(Service):
         self.interval = self.config.get('interval', 10)
 
         self.power = self.make_data_stream('power', 'float64', [1], 20)
-
         self.dark = self.make_data_stream('power', 'float64', [1], 20)
-        self.dark.submit_data(np.array([0.], dtype='float64'))
 
     def main(self):
         while not self.should_shut_down:

--- a/catkit2/services/thorlabs_pm_sim/thorlabs_pm_sim.py
+++ b/catkit2/services/thorlabs_pm_sim/thorlabs_pm_sim.py
@@ -10,7 +10,7 @@ class ThorlabsPMSim(Service):
         self.interval = self.config.get('interval', 10)
 
         self.power = self.make_data_stream('power', 'float64', [1], 20)
-        self.dark = self.make_data_stream('power', 'float64', [1], 20)
+        self.dark = self.make_data_stream('dark', 'float64', [1], 20)
 
     def main(self):
         while not self.should_shut_down:

--- a/catkit2/services/thorlabs_pm_sim/thorlabs_pm_sim.py
+++ b/catkit2/services/thorlabs_pm_sim/thorlabs_pm_sim.py
@@ -10,6 +10,9 @@ class ThorlabsPMSim(Service):
 
         self.power = self.make_data_stream('power', 'float64', [1], 20)
 
+        self.dark = self.make_data_stream('power', 'float64', [1], 20)
+        self.dark.submit_data(np.array([0.], dtype='float64'))
+
     def main(self):
         while not self.should_shut_down:
             power = self.get_power()

--- a/catkit2/services/thorlabs_pm_sim/thorlabs_pm_sim.py
+++ b/catkit2/services/thorlabs_pm_sim/thorlabs_pm_sim.py
@@ -16,6 +16,9 @@ class ThorlabsPMSim(Service):
             power = self.get_power()
             self.power.submit_data(np.array([power], dtype='float64'))
 
+            # Keep dark data stream updating with zero in simulation.
+            self.dark.submit_data(np.array([0], dtype='float64'))
+
             self.sleep(self.interval)
 
     def get_power(self):

--- a/docs/services/thorlabs_pm.rst
+++ b/docs/services/thorlabs_pm.rst
@@ -27,3 +27,5 @@ None.
 Datastreams
 -----------
 ``power``: The measured power in W.
+
+``dark``: The measured dark level in W.


### PR DESCRIPTION
Adds a `dark` data stream to hardware and simulated power meter service, and updates the service doc.

Before merging:
Need to figure out how to not submit the default value 1. when trying to measure a dark in simulation. This is done on hardware by turning off the lights, which the power meter service has no knowledge of.

Might also consider removing the default zero frame on the stream since it would be better to get an error if no dark was measured yet instead of quietly just doing no dark correction (by subtracting zero).