### PR TITLE
Fix memory lifetime for Shareable objects.

### DIFF
--- a/benchmarks/buddy_allocator.cpp
+++ b/benchmarks/buddy_allocator.cpp
@@ -1,5 +1,7 @@
 #include "BuddyAllocator.h"
 #include "Timing.h"
+#include "LocalMemory.h"
+
 #include <iostream>
 
 void benchmark_linux_scalability()
@@ -11,7 +13,7 @@ void benchmark_linux_scalability()
 	auto *handles = new BuddyAllocator::Handle[N];
 
 	size_t buffer_size = BuddyAllocator::GetSharedStateSize(MAX_SIZE, BLOCK_SIZE);
-	char *buffer = new char[buffer_size];
+	auto buffer = LocalMemory::Create(buffer_size);
 
 	auto stream = StructStream(buffer);
 	auto allocator = BuddyAllocator::Create(stream, MAX_SIZE, BLOCK_SIZE);
@@ -50,7 +52,7 @@ void benchmark_threadtest()
 	auto *handles = new BuddyAllocator::Handle[M];
 
 	size_t buffer_size = BuddyAllocator::GetSharedStateSize(MAX_SIZE, BLOCK_SIZE);
-	char *buffer = new char[buffer_size];
+	auto buffer = LocalMemory::Create(buffer_size);
 
 	auto stream = StructStream(buffer);
 	auto allocator = BuddyAllocator::Create(stream, MAX_SIZE, BLOCK_SIZE);
@@ -97,7 +99,7 @@ void benchmark_larson()
 		handles[i] = BuddyAllocator::INVALID_HANDLE;
 
 	size_t buffer_size = BuddyAllocator::GetSharedStateSize(SIZE, BLOCK_SIZE);
-	char *buffer = new char[buffer_size];
+	auto buffer = LocalMemory::Create(buffer_size);
 
 	auto stream = StructStream(buffer);
 	auto allocator = BuddyAllocator::Create(stream, SIZE, BLOCK_SIZE);

--- a/benchmarks/buddy_allocator.cpp
+++ b/benchmarks/buddy_allocator.cpp
@@ -38,7 +38,6 @@ void benchmark_linux_scalability()
     std::cout << "Time per operation: " << (end - start) / (2 * N) << " ns" << std::endl;
 
 	delete[] handles;
-	delete[] buffer;
 }
 
 void benchmark_threadtest()

--- a/benchmarks/event_latency.cpp
+++ b/benchmarks/event_latency.cpp
@@ -1,5 +1,6 @@
 #include "Event.h"
 #include "Timing.h"
+#include "LocalMemory.h"
 
 #include <thread>
 #include <atomic>
@@ -46,7 +47,7 @@ void fast_sleep(std::uint64_t ns)
 }
 
 std::atomic_bool ready = false;
-char *buffer = nullptr;
+std::shared_ptr<Memory> buffer = nullptr;
 std::atomic_uint64_t timestamp_start(0);
 
 void submit(size_t core_id)
@@ -151,7 +152,7 @@ int main(int argc, char *argv[])
 	}
 
 	// Create the buffer.
-	buffer = new char[1024 * 1024];
+	buffer = LocalMemory::Create(1024 * 1024;
 
 	std::size_t num_cores = std::thread::hardware_concurrency();
 
@@ -184,8 +185,6 @@ int main(int argc, char *argv[])
 			}
 		}
 	}
-
-	delete[] buffer;
 
 	return 0;
 }

--- a/benchmarks/event_latency.cpp
+++ b/benchmarks/event_latency.cpp
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
 	}
 
 	// Create the buffer.
-	buffer = LocalMemory::Create(1024 * 1024;
+	buffer = LocalMemory::Create(1024 * 1024);
 
 	std::size_t num_cores = std::thread::hardware_concurrency();
 

--- a/benchmarks/hash_map.cpp
+++ b/benchmarks/hash_map.cpp
@@ -1,5 +1,6 @@
 #include "HashMap.h"
 #include "Timing.h"
+#include "LocalMemory.h"
 
 #include <iostream>
 #include <cstdint>
@@ -10,7 +11,7 @@ int main(int argc, char **argv)
     std::size_t buffer_size = HashMap::GetSharedStateSize(65536, 13, sizeof(std::int16_t));
     std::cout << "Buffer size: " << buffer_size << " bytes" << std::endl;
 
-    char *buffer = new char[buffer_size];
+    auto buffer = LocalMemory::Create(buffer_size);
     auto stream = StructStream(buffer);
 
     auto map = HashMap::Create(stream, 65536, 13, sizeof(std::int16_t));
@@ -55,8 +56,6 @@ int main(int argc, char **argv)
     }
 
     std::cout << "Lookup time: " << total_time / N << " ns" << std::endl;
-
-    delete[] buffer;
 
     return 0;
 }

--- a/benchmarks/hybrid_pool_allocator.cpp
+++ b/benchmarks/hybrid_pool_allocator.cpp
@@ -1,5 +1,6 @@
 #include "HybridPoolAllocator.h"
 #include "Timing.h"
+#include "LocalMemory.h"
 #include <iostream>
 
 void benchmark_linux_scalability()
@@ -12,7 +13,7 @@ void benchmark_linux_scalability()
 	auto *handles = new HybridPoolAllocator::Handle[N];
 
 	size_t buffer_size = HybridPoolAllocator::GetSharedStateSize(MAX_SIZE, BLOCK_SIZE);
-	char *buffer = new char[buffer_size];
+	auto buffer = LocalMemory::Create(buffer_size);
 
 	auto stream = StructStream(buffer);
 	auto allocator = HybridPoolAllocator::Create(stream, MAX_SIZE, BLOCK_SIZE, MIN_POOL_SIZE);
@@ -52,7 +53,7 @@ void benchmark_threadtest()
 	auto *handles = new HybridPoolAllocator::Handle[M];
 
 	size_t buffer_size = HybridPoolAllocator::GetSharedStateSize(MAX_SIZE, BLOCK_SIZE);
-	char *buffer = new char[buffer_size];
+	auto buffer = LocalMemory::Create(buffer_size);
 
 	auto stream = StructStream(buffer);
 	auto allocator = HybridPoolAllocator::Create(stream, MAX_SIZE, BLOCK_SIZE, MIN_POOL_SIZE);
@@ -100,7 +101,7 @@ void benchmark_larson()
 		handles[i] = HybridPoolAllocator::INVALID_HANDLE;
 
 	size_t buffer_size = HybridPoolAllocator::GetSharedStateSize(SIZE, BLOCK_SIZE);
-	char *buffer = new char[buffer_size];
+	auto buffer = LocalMemory::Create(buffer_size);
 
 	auto stream = StructStream(buffer);
 	auto allocator = HybridPoolAllocator::Create(stream, SIZE, BLOCK_SIZE, MIN_POOL_SIZE);

--- a/benchmarks/hybrid_pool_allocator.cpp
+++ b/benchmarks/hybrid_pool_allocator.cpp
@@ -38,7 +38,6 @@ void benchmark_linux_scalability()
     std::cout << "Time per operation: " << (end - start) / (2 * N) << " ns" << std::endl;
 
 	delete[] handles;
-	delete[] buffer;
 }
 
 void benchmark_threadtest()

--- a/benchmarks/message_broker.cpp
+++ b/benchmarks/message_broker.cpp
@@ -1,12 +1,13 @@
 #include <iostream>
 
 #include "MessageBroker.h"
+#include "LocalMemory.h"
 
 const size_t NUM_MESSAGES = 10000000;
 
 int main(int argc, char *argv[])
 {
-	char *buffer = new char[1024 * 1024 * 512];
+	auto buffer = LocalMemory::Create(1024 * 1024 * 512);
 	auto stream = StructStream(buffer);
 
 	std::vector<std::shared_ptr<Memory>> memory_blocks;

--- a/benchmarks/pool_allocator.cpp
+++ b/benchmarks/pool_allocator.cpp
@@ -1,6 +1,7 @@
 #include "PoolAllocator.h"
 #include "Timing.h"
 #include "StructStream.h"
+#include "LocalMemory.h"
 #include <iostream>
 
 void benchmark_linux_scalability()
@@ -8,7 +9,7 @@ void benchmark_linux_scalability()
 	const size_t N = 10000000;
 	const size_t CAPACITY = 2 * N;
 
-	char *buffer = new char[PoolAllocator::GetSharedStateSize(CAPACITY)];
+	auto buffer = LocalMemory::Create(PoolAllocator::GetSharedStateSize(CAPACITY));
 	auto stream = StructStream(buffer);
 
 	auto allocator = PoolAllocator::Create(stream, CAPACITY);
@@ -35,7 +36,6 @@ void benchmark_linux_scalability()
 	std::cout << "Time per operation: " << (end - start) / (2 * N) << " ns" << std::endl;
 
 	delete[] handles;
-	delete[] buffer;
 }
 
 int main(int argc, char **argv)

--- a/catkit2/bindings.cpp
+++ b/catkit2/bindings.cpp
@@ -1033,12 +1033,12 @@ PYBIND11_MODULE(catkit_bindings, m)
 	py::class_<Event, std::shared_ptr<Event>>(m, "Event")
 		.def_static("create", [](std::shared_ptr<Memory> memory, std::string id)
 		{
-			auto stream = StructStream(memory->GetAddress());
+			auto stream = StructStream(memory);
 			return Event::Create(stream, id);
 		})
 		.def_static("open", [](std::shared_ptr<Memory> memory)
 		{
-			auto stream = StructStream(memory->GetAddress());
+			auto stream = StructStream(memory);
 			return Event::Open(stream);
 		})
 		.def("wait", [](std::shared_ptr<Event> event, py::object condition, double timeout_in_seconds, EventWaitMethod wait_method)
@@ -1091,14 +1091,14 @@ PYBIND11_MODULE(catkit_bindings, m)
 	py::class_<MessageBroker, std::shared_ptr<MessageBroker>>(m, "MessageBroker")
 		.def_static("create", [](std::shared_ptr<Memory> header, std::vector<std::shared_ptr<Memory>> memory_blocks)
 		{
-			auto stream = StructStream(header->GetAddress());
+			auto stream = StructStream(header);
 			auto broker = MessageBroker::Create(stream, memory_blocks);
 
 			return std::shared_ptr<MessageBroker>(std::move(broker));
 		})
 		.def_static("open", [](std::shared_ptr<Memory> memory)
 		{
-			auto stream = StructStream(memory->GetAddress());
+			auto stream = StructStream(memory);
 			auto broker = MessageBroker::Open(stream);
 
 			return std::shared_ptr<MessageBroker>(std::move(broker));
@@ -1207,14 +1207,14 @@ PYBIND11_MODULE(catkit_bindings, m)
 	py::class_<PoolAllocator, std::shared_ptr<PoolAllocator>>(m, "PoolAllocator")
 		.def_static("create", [](std::shared_ptr<Memory> memory, std::uint32_t capacity)
 		{
-			auto stream = StructStream(memory->GetAddress());
+			auto stream = StructStream(memory);
 			auto allocator = PoolAllocator::Create(stream, capacity);
 
 			return std::shared_ptr<PoolAllocator>(std::move(allocator));
 		})
 		.def_static("open", [](std::shared_ptr<Memory> memory)
 		{
-			auto stream = StructStream(memory->GetAddress());
+			auto stream = StructStream(memory);
 			auto allocator = PoolAllocator::Open(stream);
 
 			return std::shared_ptr<PoolAllocator>(std::move(allocator));
@@ -1234,14 +1234,14 @@ PYBIND11_MODULE(catkit_bindings, m)
 	py::class_<BuddyAllocator, std::shared_ptr<BuddyAllocator>>(m, "BuddyAllocator")
 		.def_static("create", [](std::shared_ptr<Memory> memory, std::size_t max_size, std::size_t min_size)
 		{
-			auto stream = StructStream(memory->GetAddress());
+			auto stream = StructStream(memory);
 			auto allocator = BuddyAllocator::Create(stream, max_size, min_size);
 
 			return std::shared_ptr<BuddyAllocator>(std::move(allocator));
 		})
 		.def_static("open", [](std::shared_ptr<Memory> memory)
 		{
-			auto stream = StructStream(memory->GetAddress());
+			auto stream = StructStream(memory);
 			auto allocator = BuddyAllocator::Open(stream);
 
 			return std::shared_ptr<BuddyAllocator>(std::move(allocator));
@@ -1262,14 +1262,14 @@ PYBIND11_MODULE(catkit_bindings, m)
 	py::class_<HybridPoolAllocator, std::shared_ptr<HybridPoolAllocator>>(m, "HybridPoolAllocator")
 		.def_static("create", [](std::shared_ptr<Memory> memory, std::size_t max_size, std::size_t min_size, std::size_t min_size_pool)
 		{
-			auto stream = StructStream(memory->GetAddress());
+			auto stream = StructStream(memory);
 			auto allocator = HybridPoolAllocator::Create(stream, max_size, min_size, min_size_pool);
 
 			return std::shared_ptr<HybridPoolAllocator>(std::move(allocator));
 		})
 		.def_static("open", [](std::shared_ptr<Memory> memory)
 		{
-			auto stream = StructStream(memory->GetAddress());
+			auto stream = StructStream(memory);
 			auto allocator = HybridPoolAllocator::Open(stream);
 
 			return std::shared_ptr<HybridPoolAllocator>(std::move(allocator));

--- a/catkit_core/BuddyAllocator.cpp
+++ b/catkit_core/BuddyAllocator.cpp
@@ -58,8 +58,8 @@ constexpr inline bool IsFree(std::uint16_t val)
 	return ~(val & BUSY);
 }
 
-BuddyAllocator::BuddyAllocator(std::size_t capacity, std::size_t min_size, std::atomic_uint16_t *tree, std::atomic_size_t *last_success)
-	: m_Capacity(capacity), m_MinSize(min_size), m_Depth(bit_width(capacity / min_size) - 1), m_Tree(tree), m_LastSuccessfulAllocation(last_success)
+BuddyAllocator::BuddyAllocator(std::size_t capacity, std::size_t min_size, std::atomic_uint16_t *tree, std::atomic_size_t *last_success, std::shared_ptr<Memory> memory_block)
+	: Shareable(memory_block), m_Capacity(capacity), m_MinSize(min_size), m_Depth(bit_width(capacity / min_size) - 1), m_Tree(tree), m_LastSuccessfulAllocation(last_success)
 {
 	// Check that min_size and capacity are powers of two.
 	if ((min_size & (min_size - 1)) != 0)
@@ -95,7 +95,7 @@ std::shared_ptr<BuddyAllocator> BuddyAllocator::Create(StructStream &stream, std
 		last_success[i].store((1 << (depth - 1)) - 1);
 	}
 
-	return std::shared_ptr<BuddyAllocator>(new BuddyAllocator(capacity, min_size, tree, last_success));
+	return std::shared_ptr<BuddyAllocator>(new BuddyAllocator(capacity, min_size, tree, last_success, stream.GetBuffer()));
 }
 
 std::shared_ptr<BuddyAllocator> BuddyAllocator::Open(StructStream &stream)
@@ -110,7 +110,7 @@ std::shared_ptr<BuddyAllocator> BuddyAllocator::Open(StructStream &stream)
 	auto tree = stream.Extract<std::atomic_uint16_t>(1 << (depth + 1));
 	auto last_success = stream.Extract<std::atomic_size_t>(depth + 1);
 
-	return std::shared_ptr<BuddyAllocator>(new BuddyAllocator(capacity, min_size, tree, last_success));
+	return std::shared_ptr<BuddyAllocator>(new BuddyAllocator(capacity, min_size, tree, last_success, stream.GetBuffer()));
 }
 
 std::size_t BuddyAllocator::GetSharedStateSize(std::size_t capacity, std::size_t min_size)

--- a/catkit_core/BuddyAllocator.h
+++ b/catkit_core/BuddyAllocator.h
@@ -33,7 +33,7 @@ public:
 	void PrintState() const;
 
 private:
-	BuddyAllocator(std::size_t capacity, std::size_t min_size, std::atomic_uint16_t *tree, std::atomic_size_t *last_success);
+	BuddyAllocator(std::size_t capacity, std::size_t min_size, std::atomic_uint16_t *tree, std::atomic_size_t *last_success, std::shared_ptr<Memory> memory_block);
 
 	Handle TryAllocate(Handle index);
 

--- a/catkit_core/DataStream.cpp
+++ b/catkit_core/DataStream.cpp
@@ -92,7 +92,7 @@ std::shared_ptr<DataStream> DataStream::Create(std::string_view stream_name, std
 	std::shared_ptr<SharedMemory> header_shared_memory = SharedMemory::Create(std::string(stream_id) + ".hdr", sizeof(DataStreamHeader));
 
 	// Create the StructStream to read from the created shared memory object.
-	auto stream = StructStream(header_shared_memory->GetAddress());
+	auto stream = StructStream(header_shared_memory);
 
 	return DataStream::Create(stream, stream_name, service_id, type, dimensions, num_frames_in_buffer, std::move(header_shared_memory));
 }
@@ -148,7 +148,7 @@ std::shared_ptr<DataStream> DataStream::Open(std::string_view stream_id)
 {
 	// Open the shared memory for the header and extract shared state.
 	auto header_shared_memory = SharedMemory::Open(std::string(stream_id) + ".hdr");
-	auto stream = StructStream(header_shared_memory->GetAddress());
+	auto stream = StructStream(header_shared_memory);
 
 	// Open the data stream and return it.
 	return DataStream::Open(stream, std::move(header_shared_memory));

--- a/catkit_core/DataStream.cpp
+++ b/catkit_core/DataStream.cpp
@@ -69,8 +69,8 @@ void CopyString(char *dest, const char *src, size_t n)
 	snprintf(dest, n, "%s", src);
 }
 
-DataStream::DataStream(DataStreamHeader *header, std::shared_ptr<SharedMemory> buffer_shared_memory, std::shared_ptr<SharedMemory> header_shared_memory, std::shared_ptr<Event> event)
-	: m_HeaderSharedMemory(std::move(header_shared_memory)),
+DataStream::DataStream(DataStreamHeader *header, std::shared_ptr<SharedMemory> buffer_shared_memory, std::shared_ptr<Memory> header_shared_memory, std::shared_ptr<Event> event)
+	: Shareable(header_shared_memory),
 	m_BufferSharedMemory(std::move(buffer_shared_memory)),
 	m_Event(std::move(event)),
 	m_Header(header),
@@ -94,10 +94,10 @@ std::shared_ptr<DataStream> DataStream::Create(std::string_view stream_name, std
 	// Create the StructStream to read from the created shared memory object.
 	auto stream = StructStream(header_shared_memory);
 
-	return DataStream::Create(stream, stream_name, service_id, type, dimensions, num_frames_in_buffer, std::move(header_shared_memory));
+	return DataStream::Create(stream, stream_name, service_id, type, dimensions, num_frames_in_buffer);
 }
 
-std::shared_ptr<DataStream> DataStream::Create(StructStream &stream, std::string_view stream_name, std::string_view service_id, DataType type, std::vector<size_t> dimensions, size_t num_frames_in_buffer, std::shared_ptr<SharedMemory> header_shared_memory)
+std::shared_ptr<DataStream> DataStream::Create(StructStream &stream, std::string_view stream_name, std::string_view service_id, DataType type, std::vector<size_t> dimensions, size_t num_frames_in_buffer)
 {
 	// Compute the buffer size.
 	size_t num_elements_per_frame, num_bytes_per_frame, num_bytes_in_buffer;
@@ -136,7 +136,7 @@ std::shared_ptr<DataStream> DataStream::Create(StructStream &stream, std::string
 	header->m_NumBytesInBuffer = num_bytes_in_buffer;
 
 	// Create the data stream object.
-	auto data_stream = std::shared_ptr<DataStream>(new DataStream(header, std::move(buffer_shared_memory), std::move(header_shared_memory), std::move(event)));
+	auto data_stream = std::shared_ptr<DataStream>(new DataStream(header, std::move(buffer_shared_memory), stream.GetBuffer(), std::move(event)));
 
 	// Update the parameters of the data stream.
 	data_stream->UpdateParameters(type, dimensions, num_frames_in_buffer);
@@ -151,10 +151,10 @@ std::shared_ptr<DataStream> DataStream::Open(std::string_view stream_id)
 	auto stream = StructStream(header_shared_memory);
 
 	// Open the data stream and return it.
-	return DataStream::Open(stream, std::move(header_shared_memory));
+	return DataStream::Open(stream);
 }
 
-std::shared_ptr<DataStream> DataStream::Open(StructStream &stream, std::shared_ptr<SharedMemory> header_shared_memory)
+std::shared_ptr<DataStream> DataStream::Open(StructStream &stream)
 {
 	if (!CheckVersion(stream, CURRENT_DATASTREAM_VERSION))
 		return nullptr;
@@ -168,7 +168,7 @@ std::shared_ptr<DataStream> DataStream::Open(StructStream &stream, std::shared_p
 	auto event = Event::Open(stream);
 
 	// Create data stream object.
-	auto data_stream = std::shared_ptr<DataStream>(new DataStream(header, std::move(buffer_shared_memory), std::move(header_shared_memory), std::move(event)));
+	auto data_stream = std::shared_ptr<DataStream>(new DataStream(header, std::move(buffer_shared_memory), stream.GetBuffer(), std::move(event)));
 
 	// Don't read frames that already are available at the time the data stream is opened.
 	data_stream->m_NextFrameIdToRead = data_stream->m_Header->m_LastId;

--- a/catkit_core/DataStream.h
+++ b/catkit_core/DataStream.h
@@ -65,14 +65,14 @@ enum BufferHandlingMode
 class DataStream : public Shareable
 {
 private:
-	DataStream(DataStreamHeader *header, std::shared_ptr<SharedMemory> buffer_shared_memory, std::shared_ptr<SharedMemory> header_shared_memory, std::shared_ptr<Event> event);
+	DataStream(DataStreamHeader *header, std::shared_ptr<SharedMemory> buffer_shared_memory, std::shared_ptr<Memory> header_shared_memory, std::shared_ptr<Event> event);
 
 public:
 	~DataStream();
 
 	static std::shared_ptr<DataStream> Create(std::string_view stream_name, std::string_view service_id, DataType type, std::vector<size_t> dimensions, size_t num_frames_in_buffer);
-	static std::shared_ptr<DataStream> Create(StructStream &stream, std::string_view stream_name, std::string_view service_id, DataType type, std::vector<size_t> dimensions, size_t num_frames_in_buffer, std::shared_ptr<SharedMemory> header_shared_memory = nullptr);
-	static std::shared_ptr<DataStream> Open(StructStream &stream, std::shared_ptr<SharedMemory> header_shared_memory = nullptr);
+	static std::shared_ptr<DataStream> Create(StructStream &stream, std::string_view stream_name, std::string_view service_id, DataType type, std::vector<size_t> dimensions, size_t num_frames_in_buffer);
+	static std::shared_ptr<DataStream> Open(StructStream &stream);
 	static std::shared_ptr<DataStream> Open(std::string_view stream_id);
 
 	DataFrame RequestNewFrame();
@@ -124,7 +124,6 @@ private:
 	size_t m_NextFrameIdToRead;
 	BufferHandlingMode m_BufferHandlingMode;
 
-	std::shared_ptr<SharedMemory> m_HeaderSharedMemory;
 	std::shared_ptr<SharedMemory> m_BufferSharedMemory;
 };
 

--- a/catkit_core/Event.cpp
+++ b/catkit_core/Event.cpp
@@ -1,5 +1,10 @@
 #include "Event.h"
 
+Event::Event(std::shared_ptr<Memory> memory_block)
+	: Shareable(memory_block)
+{
+}
+
 void Event::Wait(double timeout_in_sec, std::function<bool()> condition, EventWaitMethod wait_method, void (*error_check)())
 {
 	// Wait for a specific event type.
@@ -38,7 +43,7 @@ std::shared_ptr<Event> Event::Create(StructStream &stream, std::string_view id)
 	header->m_Id.fill('\0');
 	id.copy(header->m_Id.data(), EVENT_ID_MAX_SIZE - 1);
 
-	auto event = std::shared_ptr<Event>(new Event());
+	auto event = std::shared_ptr<Event>(new Event(stream.GetBuffer()));
 
 	// Create all event types.
 	event->m_ConditionVariable = EventConditionVariable::Create(id, &header->m_ConditionVariable);
@@ -51,7 +56,7 @@ std::shared_ptr<Event> Event::Create(StructStream &stream, std::string_view id)
 
 std::shared_ptr<Event> Event::Open(StructStream &stream)
 {
-	std::shared_ptr<Event> event(new Event());
+	std::shared_ptr<Event> event(new Event(stream.GetBuffer()));
 
 	auto header = stream.Extract<Header>();
 

--- a/catkit_core/Event.h
+++ b/catkit_core/Event.h
@@ -26,6 +26,8 @@ enum class EventWaitMethod
 class Event : public Shareable
 {
 private:
+	Event(std::shared_ptr<Memory> memory_block);
+
 	static const int EVENT_ID_MAX_SIZE = 256;
 
 	struct Header

--- a/catkit_core/HashMap.cpp
+++ b/catkit_core/HashMap.cpp
@@ -124,8 +124,9 @@ void *HashMap::GetValue(std::size_t entry) const
 	return m_Data + i;
 }
 
-HashMap::HashMap(char *data, std::size_t num_entries, std::size_t max_key_size, std::size_t value_size)
-	: m_Data(data),
+HashMap::HashMap(char *data, std::size_t num_entries, std::size_t max_key_size, std::size_t value_size, std::shared_ptr<Memory> memory_block)
+	: Shareable(memory_block),
+	m_Data(data),
 	m_NumEntries(num_entries),
 	m_MaxKeySize(max_key_size),
 	m_ValueSize(value_size),
@@ -156,7 +157,7 @@ std::shared_ptr<HashMap> HashMap::Create(StructStream &stream, std::size_t num_e
 
 	auto data = stream.Extract<char>(CalculateEntrySize(max_key_size, value_size) * num_entries);
 
-	auto map = std::shared_ptr<HashMap>(new HashMap(data, num_entries, max_key_size, value_size));
+	auto map = std::shared_ptr<HashMap>(new HashMap(data, num_entries, max_key_size, value_size, stream.GetBuffer()));
 
 	// Initialize the map.
 	for (std::size_t i = 0; i < map->m_NumEntries; ++i)
@@ -175,7 +176,7 @@ std::shared_ptr<HashMap> HashMap::Open(StructStream &stream)
 	auto value_size = *stream.Extract<std::size_t>();
 	auto data = stream.Extract<char>(CalculateEntrySize(max_key_size, value_size) * num_entries);
 
-	return std::shared_ptr<HashMap>(new HashMap(data, num_entries, max_key_size, value_size));
+	return std::shared_ptr<HashMap>(new HashMap(data, num_entries, max_key_size, value_size, stream.GetBuffer()));
 }
 
 void *HashMap::Insert(std::string_view key, const void *value)

--- a/catkit_core/HashMap.h
+++ b/catkit_core/HashMap.h
@@ -42,7 +42,7 @@ private:
 	static std::size_t CalculateEntrySize(std::size_t max_key_size, std::size_t value_size);
 
 public:
-	HashMap(char *data, std::size_t num_entries, std::size_t max_key_size, std::size_t value_size);
+	HashMap(char *data, std::size_t num_entries, std::size_t max_key_size, std::size_t value_size, std::shared_ptr<Memory> memory_block);
 
 	static std::size_t GetSharedStateSize(std::size_t num_entries, std::size_t max_key_size, std::size_t value_size);
 

--- a/catkit_core/HybridPoolAllocator.cpp
+++ b/catkit_core/HybridPoolAllocator.cpp
@@ -10,8 +10,8 @@
 
 const std::array<std::uint8_t, 4> HYBRID_POOL_ALLOCATOR_VERSION = {0, 0, 0, 0};
 
-HybridPoolAllocator::HybridPoolAllocator(std::size_t capacity, std::size_t min_size, std::size_t min_size_pool, std::shared_ptr<BuddyAllocator> allocator, Pool *pools)
-	: m_Capacity(capacity), m_MinSize(min_size), m_MinSizePool(min_size_pool), m_Allocator(std::move(allocator)), m_Pools(pools)
+HybridPoolAllocator::HybridPoolAllocator(std::size_t capacity, std::size_t min_size, std::size_t min_size_pool, std::shared_ptr<BuddyAllocator> allocator, Pool *pools, std::shared_ptr<Memory> memory_block)
+	: Shareable(memory_block), m_Capacity(capacity), m_MinSize(min_size), m_MinSizePool(min_size_pool), m_Allocator(std::move(allocator)), m_Pools(pools)
 {
 }
 
@@ -58,7 +58,7 @@ std::shared_ptr<HybridPoolAllocator> HybridPoolAllocator::Create(StructStream &s
 	for (std::size_t i = 0; i < buddy_allocator_num_blocks; ++i)
 		pools[i].map = 0;
 
-	return std::shared_ptr<HybridPoolAllocator>(new HybridPoolAllocator(capacity, min_size, min_size_pool, std::move(allocator), pools));
+	return std::shared_ptr<HybridPoolAllocator>(new HybridPoolAllocator(capacity, min_size, min_size_pool, std::move(allocator), pools, stream.GetBuffer()));
 }
 
 std::shared_ptr<HybridPoolAllocator> HybridPoolAllocator::Open(StructStream &stream)
@@ -78,7 +78,7 @@ std::shared_ptr<HybridPoolAllocator> HybridPoolAllocator::Open(StructStream &str
 
 	auto pools = stream.Extract<Pool>(buddy_allocator_num_blocks);
 
-	return std::shared_ptr<HybridPoolAllocator>(new HybridPoolAllocator(capacity, min_size, min_size_pool, std::move(allocator), pools));
+	return std::shared_ptr<HybridPoolAllocator>(new HybridPoolAllocator(capacity, min_size, min_size_pool, std::move(allocator), pools, stream.GetBuffer()));
 }
 
 ShareableType HybridPoolAllocator::GetType() const

--- a/catkit_core/HybridPoolAllocator.h
+++ b/catkit_core/HybridPoolAllocator.h
@@ -41,7 +41,7 @@ public:
 	std::size_t GetOffset(Handle handle) const;
 
 public:
-	HybridPoolAllocator(std::size_t capacity, std::size_t min_size, std::size_t min_size_pool, std::shared_ptr<BuddyAllocator> allocator, Pool *pools);
+	HybridPoolAllocator(std::size_t capacity, std::size_t min_size, std::size_t min_size_pool, std::shared_ptr<BuddyAllocator> allocator, Pool *pools, std::shared_ptr<Memory> memory_block);
 	~HybridPoolAllocator();
 
 	std::size_t GetLevelFromHandle(Handle handle) const;

--- a/catkit_core/LocalMemory.cpp
+++ b/catkit_core/LocalMemory.cpp
@@ -68,3 +68,8 @@ ShareableType LocalMemory::GetType() const
 {
 	return ShareableType::LocalMemory;
 }
+
+MemoryType LocalMemory::GetMemoryType() const
+{
+	return MemoryType::LocalMemory;
+}

--- a/catkit_core/LocalMemory.cpp
+++ b/catkit_core/LocalMemory.cpp
@@ -23,11 +23,11 @@ std::size_t LocalMemory::GetCapacity() const
 	return m_Capacity;
 }
 
-void LocalMemory::WriteReference(StructStream &stream)
+void LocalMemory::WriteReference(StructStream *stream)
 {
-	*stream.Extract<char *>() = m_Memory;
-	*stream.Extract<std::size_t>() = m_Capacity;
-	*stream.Extract<int>() = GetProcessId();
+	*stream->Extract<char *>() = m_Memory;
+	*stream->Extract<std::size_t>() = m_Capacity;
+	*stream->Extract<int>() = GetProcessId();
 }
 
 std::shared_ptr<LocalMemory> LocalMemory::Create(StructStream &stream, std::size_t num_bytes)

--- a/catkit_core/LocalMemory.cpp
+++ b/catkit_core/LocalMemory.cpp
@@ -3,7 +3,7 @@
 #include <stdexcept>
 
 LocalMemory::LocalMemory(char *memory, std::size_t num_bytes, bool is_owner)
-	: m_Memory(memory), m_Capacity(num_bytes), m_IsOwner(is_owner)
+	: Shareable(nullptr), m_Memory(memory), m_Capacity(num_bytes), m_IsOwner(is_owner)
 {
 }
 

--- a/catkit_core/LocalMemory.h
+++ b/catkit_core/LocalMemory.h
@@ -16,7 +16,7 @@ public:
 
     virtual void *GetAddress(std::size_t offset = 0) override;
     virtual std::size_t GetCapacity() const override;
-    virtual void WriteReference(StructStream &stream) override;
+    virtual void WriteReference(StructStream *stream) override;
 
     virtual ShareableType GetType() const override;
     virtual MemoryType GetMemoryType() const override;

--- a/catkit_core/LocalMemory.h
+++ b/catkit_core/LocalMemory.h
@@ -5,7 +5,7 @@
 #include "Shareable.h"
 #include "Util.h"
 
-class LocalMemory : public Memory
+class LocalMemory : public Memory, public Shareable
 {
 public:
     virtual ~LocalMemory();
@@ -19,6 +19,7 @@ public:
     virtual void WriteReference(StructStream &stream) override;
 
     virtual ShareableType GetType() const override;
+    virtual MemoryType GetMemoryType() const override;
 
 private:
     LocalMemory(char *memory, std::size_t num_bytes, bool is_owner);

--- a/catkit_core/Memory.h
+++ b/catkit_core/Memory.h
@@ -2,17 +2,24 @@
 #define MEMORY_H
 
 #include "StructStream.h"
-#include "Shareable.h"
 
 #include <cstddef>
 
-class Memory : public Shareable
+enum class MemoryType
+{
+	SharedMemory,
+	LocalMemory
+};
+
+class Memory
 {
 public:
 	virtual ~Memory() = default;
 
 	virtual void *GetAddress(std::size_t offset = 0) = 0;
 	virtual std::size_t GetCapacity() const = 0;
+
+	virtual MemoryType GetMemoryType() const = 0;
 
 	virtual void WriteReference(StructStream &stream) = 0;
 };

--- a/catkit_core/Memory.h
+++ b/catkit_core/Memory.h
@@ -1,9 +1,9 @@
 #ifndef MEMORY_H
 #define MEMORY_H
 
-#include "StructStream.h"
-
 #include <cstddef>
+
+class StructStream;
 
 enum class MemoryType
 {
@@ -21,7 +21,7 @@ public:
 
 	virtual MemoryType GetMemoryType() const = 0;
 
-	virtual void WriteReference(StructStream &stream) = 0;
+	virtual void WriteReference(StructStream *stream) = 0;
 };
 
 #endif // MEMORY_H

--- a/catkit_core/MessageBroker.cpp
+++ b/catkit_core/MessageBroker.cpp
@@ -147,9 +147,11 @@ MessageBroker::MessageBroker(
 	std::shared_ptr<PoolAllocator> message_header_allocator,
 	std::shared_ptr<Event> event,
 	std::vector<std::shared_ptr<HybridPoolAllocator>> allocators,
-	std::vector<std::shared_ptr<Memory>> memory_blocks
+	std::vector<std::shared_ptr<Memory>> memory_blocks,
+	std::shared_ptr<Memory> header_memory
 )
-	: m_Header(header),
+	: Shareable(header_memory),
+	m_Header(header),
 	m_TopicHeaders(std::move(topic_headers)),
 	m_MessageHeaderAllocator(std::move(message_header_allocator)),
 	m_Event(std::move(event)),
@@ -210,7 +212,8 @@ std::shared_ptr<MessageBroker> MessageBroker::Create(StructStream &stream, std::
 		std::move(message_header_allocator),
 		std::move(event),
 		allocators,
-		memory_blocks
+		memory_blocks,
+		stream.GetBuffer()
 	));
 }
 
@@ -252,7 +255,8 @@ std::shared_ptr<MessageBroker> MessageBroker::Open(StructStream &stream)
 		std::move(message_header_allocator),
 		std::move(event),
 		allocators,
-		memory_blocks
+		memory_blocks,
+		stream.GetBuffer()
 	));
 }
 

--- a/catkit_core/MessageBroker.cpp
+++ b/catkit_core/MessageBroker.cpp
@@ -201,7 +201,7 @@ std::shared_ptr<MessageBroker> MessageBroker::Create(StructStream &stream, std::
 		allocators.push_back(std::move(allocator));
 
 		*stream.Extract<MemoryType>() = memory_block->GetMemoryType();
-		memory_block->WriteReference(stream);
+		memory_block->WriteReference(&stream);
 	}
 
 	DEBUG_PRINT("Creating object.");

--- a/catkit_core/MessageBroker.cpp
+++ b/catkit_core/MessageBroker.cpp
@@ -198,7 +198,7 @@ std::shared_ptr<MessageBroker> MessageBroker::Create(StructStream &stream, std::
 
 		allocators.push_back(std::move(allocator));
 
-		*stream.Extract<ShareableType>() = memory_block->GetType();
+		*stream.Extract<MemoryType>() = memory_block->GetMemoryType();
 		memory_block->WriteReference(stream);
 	}
 
@@ -232,13 +232,13 @@ std::shared_ptr<MessageBroker> MessageBroker::Open(StructStream &stream)
 		auto allocator = HybridPoolAllocator::Open(stream);
 		allocators.push_back(std::move(allocator));
 
-		ShareableType type = *stream.Extract<ShareableType>();
+		MemoryType type = *stream.Extract<MemoryType>();
 		switch (type)
 		{
-			case ShareableType::SharedMemory:
+			case MemoryType::SharedMemory:
 				memory_blocks.push_back(SharedMemory::Open(stream));
 				break;
-			case ShareableType::LocalMemory:
+			case MemoryType::LocalMemory:
 				memory_blocks.push_back(LocalMemory::Open(stream));
 				break;
 			default:

--- a/catkit_core/MessageBroker.h
+++ b/catkit_core/MessageBroker.h
@@ -203,7 +203,8 @@ private:
 		std::shared_ptr<PoolAllocator> message_header_allocator,
 		std::shared_ptr<Event> event,
 		std::vector<std::shared_ptr<HybridPoolAllocator>> allocators,
-		std::vector<std::shared_ptr<Memory>> memory_blocks
+		std::vector<std::shared_ptr<Memory>> memory_blocks,
+		std::shared_ptr<Memory> header_memory
 	);
 
 public:

--- a/catkit_core/PoolAllocator.cpp
+++ b/catkit_core/PoolAllocator.cpp
@@ -5,8 +5,8 @@
 
 const std::array<std::uint8_t, 4> VERSION = {0, 0, 0, 0};
 
-PoolAllocator::PoolAllocator(std::uint32_t capacity, std::atomic<BlockHandle> *head, std::atomic<BlockHandle> *next, std::atomic_size_t *ref_count)
-	: m_Capacity(capacity), m_Head(head), m_Next(next), m_RefCount(ref_count)
+PoolAllocator::PoolAllocator(std::uint32_t capacity, std::atomic<BlockHandle> *head, std::atomic<BlockHandle> *next, std::atomic_size_t *ref_count, std::shared_ptr<Memory> memory_block)
+	: Shareable(memory_block), m_Capacity(capacity), m_Head(head), m_Next(next), m_RefCount(ref_count)
 {
 }
 
@@ -46,7 +46,7 @@ std::shared_ptr<PoolAllocator> PoolAllocator::Create(StructStream &stream, std::
 	}
 	next[capacity - 1].store(INVALID_HANDLE, std::memory_order_relaxed);
 
-	return std::shared_ptr<PoolAllocator>(new PoolAllocator(capacity, head, next, ref_count));
+	return std::shared_ptr<PoolAllocator>(new PoolAllocator(capacity, head, next, ref_count, stream.GetBuffer()));
 }
 
 std::shared_ptr<PoolAllocator> PoolAllocator::Open(StructStream &stream)
@@ -58,7 +58,7 @@ std::shared_ptr<PoolAllocator> PoolAllocator::Open(StructStream &stream)
 	auto next = stream.Extract<std::atomic<BlockHandle>>(capacity);
 	auto *ref_count = stream.Extract<std::atomic_size_t>(capacity);
 
-	return std::shared_ptr<PoolAllocator>(new PoolAllocator(capacity, head, next, ref_count));
+	return std::shared_ptr<PoolAllocator>(new PoolAllocator(capacity, head, next, ref_count, stream.GetBuffer()));
 }
 
 PoolAllocator::BlockHandle PoolAllocator::Allocate()

--- a/catkit_core/PoolAllocator.h
+++ b/catkit_core/PoolAllocator.h
@@ -29,7 +29,7 @@ public:
 	ShareableType GetType() const override;
 
 private:
-	PoolAllocator(std::uint32_t capacity, std::atomic<BlockHandle> *head, std::atomic<BlockHandle> *next, std::atomic_size_t *ref_count);
+	PoolAllocator(std::uint32_t capacity, std::atomic<BlockHandle> *head, std::atomic<BlockHandle> *next, std::atomic_size_t *ref_count, std::shared_ptr<Memory> memory_block);
 
 	std::uint32_t m_Capacity;
 	std::atomic<BlockHandle> *m_Head;

--- a/catkit_core/Shareable.cpp
+++ b/catkit_core/Shareable.cpp
@@ -12,6 +12,11 @@
 #include "BuddyAllocator.h"
 #include "HybridPoolAllocator.h"
 
+Shareable::Shareable(std::shared_ptr<Memory> memory_block)
+	: m_MemoryBlock(memory_block)
+{
+}
+
 std::shared_ptr<Shareable> Shareable::Open(StructStream &stream)
 {
 	ShareableType type = *stream.Extract<ShareableType>();

--- a/catkit_core/Shareable.h
+++ b/catkit_core/Shareable.h
@@ -31,7 +31,9 @@ enum class ShareableType
 class Shareable
 {
 protected:
-	Shareable() = default;
+	// Constructor. This stores a reference to the memory block,
+	// ensuring it stays alive at least until this object gets deallocated.
+	Shareable(std::shared_ptr<Memory> memory_block);
 
 public:
 	virtual ~Shareable() = default;
@@ -45,6 +47,10 @@ public:
 	static std::shared_ptr<Shareable> Open(StructStream &stream);
 
 	virtual ShareableType GetType() const = 0;
+
+private:
+	// The memory object containing our shared state.
+	std::shared_ptr<Memory> m_MemoryBlock;
 };
 
 template <typename T, std::size_t N>

--- a/catkit_core/SharedMemory.cpp
+++ b/catkit_core/SharedMemory.cpp
@@ -243,6 +243,11 @@ ShareableType SharedMemory::GetType() const
 	return ShareableType::SharedMemory;
 }
 
+MemoryType SharedMemory::GetMemoryType() const
+{
+	return MemoryType::SharedMemory;
+}
+
 std::size_t SharedMemory::GetCapacity() const
 {
 	return m_Capacity;

--- a/catkit_core/SharedMemory.cpp
+++ b/catkit_core/SharedMemory.cpp
@@ -195,7 +195,7 @@ std::shared_ptr<SharedMemory> SharedMemory::Open(StructStream &stream)
 }
 
 SharedMemory::SharedMemory(std::string_view fname, FileObject file, bool is_owner)
-	: m_File(file), m_FileName(fname), m_IsOwner(is_owner), m_Buffer(nullptr)
+	: Shareable(nullptr), m_File(file), m_FileName(fname), m_IsOwner(is_owner), m_Buffer(nullptr)
 {
 #ifdef _WIN32
 	m_Buffer = MapViewOfFile(m_File, FILE_MAP_ALL_ACCESS, 0, 0, 0);

--- a/catkit_core/SharedMemory.cpp
+++ b/catkit_core/SharedMemory.cpp
@@ -253,9 +253,9 @@ std::size_t SharedMemory::GetCapacity() const
 	return m_Capacity;
 }
 
-void SharedMemory::WriteReference(StructStream &stream)
+void SharedMemory::WriteReference(StructStream *stream)
 {
-	auto filename = stream.Extract<char>(SHARED_MEMORY_FNAME_SIZE);
+	auto filename = stream->Extract<char>(SHARED_MEMORY_FNAME_SIZE);
 
 	std::fill(filename, filename + SHARED_MEMORY_FNAME_SIZE, '\0');
 	m_FileName.copy(filename, SHARED_MEMORY_FNAME_SIZE - 1);

--- a/catkit_core/SharedMemory.h
+++ b/catkit_core/SharedMemory.h
@@ -60,7 +60,7 @@ public:
 
 	virtual void *GetAddress(std::size_t offset = 0) override;
 	virtual std::size_t GetCapacity() const override;
-	virtual void WriteReference(StructStream &stream) override;
+	virtual void WriteReference(StructStream *stream) override;
 
 	std::string GetFileName();
 

--- a/catkit_core/SharedMemory.h
+++ b/catkit_core/SharedMemory.h
@@ -24,7 +24,7 @@
 
 const int SHARED_MEMORY_FNAME_SIZE = 256;
 
-class SharedMemory : public Memory
+class SharedMemory : public Memory, public Shareable
 {
 public:
 	#ifdef _WIN32
@@ -64,7 +64,8 @@ public:
 
 	std::string GetFileName();
 
-	ShareableType GetType() const override;
+	virtual ShareableType GetType() const override;
+	virtual MemoryType GetMemoryType() const override;
 
 private:
 	std::string m_FileName;

--- a/catkit_core/StructStream.cpp
+++ b/catkit_core/StructStream.cpp
@@ -1,0 +1,16 @@
+#include "StructStream.h"
+
+StructStream::StructStream(std::shared_ptr<Memory> buffer, std::size_t offset)
+	: m_Buffer(buffer), m_Offset(offset)
+{
+}
+
+std::size_t StructStream::GetOffset()
+{
+	return m_Offset;
+}
+
+std::shared_ptr<Memory> StructStream::GetBuffer()
+{
+	return m_Buffer;
+}

--- a/catkit_core/StructStream.h
+++ b/catkit_core/StructStream.h
@@ -3,48 +3,30 @@
 
 #include <cstddef>
 #include <algorithm>
+#include <memory>
+
+class Memory;
 
 class StructStream
 {
 public:
-	StructStream(void *buffer)
-		: m_Buffer(reinterpret_cast<char *>(buffer)),
-	m_Offset(0)
-	{
-	}
+	StructStream(std::shared_ptr<Memory> buffer, std::size_t offset = 0);
 
 	template <typename T>
-	T *Extract(std::size_t num_elements = 1)
-	{
-		AddPadding<T>();
-
-		// Link element to the buffer.
-		T *res = reinterpret_cast<T *>(m_Buffer + m_Offset);
-
-		// Consume bytes from the buffer.
-		m_Offset += num_elements * sizeof(T);
-
-		return res;
-	}
+	T *Extract(std::size_t num_elements = 1);
 
 	template <typename... Ts>
-	inline void AddPadding()
-	{
-		// Get alignment requirement of the type.
-		constexpr std::size_t align = std::max({alignof(Ts)...});
+	inline void AddPadding();
 
-		// Pad the buffer to satisfy alignment requirement.
-		m_Offset += (align - (m_Offset % align)) % align;
-	}
+	std::size_t GetOffset();
 
-	std::size_t GetOffset()
-	{
-		return m_Offset;
-	}
+	std::shared_ptr<Memory> GetBuffer();
 
 private:
-	char *m_Buffer;
+	std::shared_ptr<Memory> m_Buffer;
 	std::size_t m_Offset;
 };
+
+#include "StructStream.inl"
 
 #endif // STRUCT_STREAM_H

--- a/catkit_core/StructStream.inl
+++ b/catkit_core/StructStream.inl
@@ -1,0 +1,27 @@
+#include "StructStream.h"
+
+#include "Memory.h"
+
+template <typename T>
+T *StructStream::Extract(std::size_t num_elements)
+{
+	AddPadding<T>();
+
+	// Link element to the buffer.
+	T *res = reinterpret_cast<T *>(m_Buffer->GetAddress(m_Offset));
+
+	// Consume bytes from the buffer.
+	m_Offset += num_elements * sizeof(T);
+
+	return res;
+}
+
+template <typename... Ts>
+void StructStream::AddPadding()
+{
+	// Get alignment requirement of the type.
+	constexpr std::size_t align = std::max({alignof(Ts)...});
+
+	// Pad the buffer to satisfy alignment requirement.
+	m_Offset += (align - (m_Offset % align)) % align;
+}

--- a/catkit_core/TestbedProxy.cpp
+++ b/catkit_core/TestbedProxy.cpp
@@ -381,7 +381,7 @@ void TestbedProxy::GetTestbedInfo()
 	m_HeartbeatStream = DataStream::Open(reply.heartbeat_stream_id());
 
 	m_MessageBrokerHeader = SharedMemory::Open(reply.message_broker_id());
-	StructStream stream = StructStream(m_MessageBrokerHeader->GetAddress());
+	StructStream stream = StructStream(m_MessageBrokerHeader);
 	m_MessageBroker = MessageBroker::Open(stream);
 
 	m_LoggingIngressPort = reply.logging_ingress_port();


### PR DESCRIPTION
Fixes #344.

This PR makes one important change. When a `Shareable` object is now created, you can pass in a shared pointer to a `Memory` object. This object is stored in the object itself, thereby keeping that memory alive until the `Shareable` object has been deallocated. This means that there will be no more cases where the memory got deallocated while the `Shareable` is still alive (which almost always leads to access errors or segmentation faults).

While this PR touches a lot of code, almost all code changes are similar: passing the buffer that the `StructStream` is based on into the constructor of `Shareable`.

Additionally, this PR splits up the header-only `StructStream.h` into a `StructStream.h`, `StructStream.cpp` and `StructStream.inl` files, as is more common in our codebase.