### PR TITLE
Add new motor stage model

### DIFF
--- a/catkit2/services/thorlabs_cube_motor_kinesis/thorlabs_cube_motor_kinesis.py
+++ b/catkit2/services/thorlabs_cube_motor_kinesis/thorlabs_cube_motor_kinesis.py
@@ -103,7 +103,7 @@ class ThorlabsCubeMotorKinesis(Service):
         self.lib.CC_Open(self.serial_number)
         self.lib.CC_StartPolling(self.serial_number, c_int(200))
 
-        if self.stage_model in ['MTS25-Z8', 'MTS50-Z8', 'Z825B', 'Z806', 'Z812']:
+        if self.stage_model in ['MTS25-Z8', 'MTS50-Z8', 'Z825B', 'Z806', 'Z812', 'Z925B']:
             # Set up the device to convert real units to device units
             steps_per_rev = c_double(512)
             gear_box_ratio = c_double(67.49)


### PR DESCRIPTION
The Z925B motor stage model has the same gear ratio, pitch and counts per revolution than the other ones.