### PR TITLE
Add tests for process stats.

### DIFF
--- a/catkit2/bindings.cpp
+++ b/catkit2/bindings.cpp
@@ -36,6 +36,7 @@
 #include "Event.h"
 #include "Uuid.h"
 #include "ArrayView.h"
+#include "ProcessStats.h"
 
 #include "testbed.pb.h"
 
@@ -1286,6 +1287,12 @@ PYBIND11_MODULE(catkit_bindings, m)
 		})
 		.def("acquire", &HybridPoolAllocator::Acquire)
 		.def("release", &HybridPoolAllocator::Release);
+
+	py::class_<ProcessStats>(m, "ProcessStats")
+		.def(py::init<>())
+		.def("update", &ProcessStats::Update)
+		.def_property_readonly("memory_usage", &ProcessStats::GetMemoryUsage)
+		.def_property_readonly("cpu_usage", &ProcessStats::GetCpuUsage);
 
 #ifdef VERSION_INFO
 	m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);

--- a/tests/test_process_stats.py
+++ b/tests/test_process_stats.py
@@ -1,0 +1,9 @@
+from catkit2.catkit_bindings import ProcessStats
+
+
+def test_process_stats():
+    stats = ProcessStats()
+    stats.update()
+
+    assert stats.memory_usage > 0
+    assert stats.cpu_usage >= 0


### PR DESCRIPTION
> [!CAUTION]
> This PR branches off from #342.

In response to https://github.com/spacetelescope/catkit2/pull/345#issuecomment-2985134924.

This PR adds a wrapper for the `ProcessStats` class and then test the output using pytest. This ensures that the functions do not crash and give at least a minimal reasonable output (memory usage positive, cpu usage non-negative).