### PR TITLE
Fix mtop call for `get_newest_message()`.

### DIFF
--- a/catkit2/tui/mtop.py
+++ b/catkit2/tui/mtop.py
@@ -35,11 +35,10 @@ def generate_data(broker):
     res = []
 
     for topic in topics:
-        last_message_id = broker.get_newest_message_id(topic)
-        if last_message_id == 0:
+        try:
+            message = broker.get_current_message(topic)
+        except Exception:
             continue
-
-        message = broker.get_newest_message(topic)
 
         if message.topic != topic:
             continue


### PR DESCRIPTION
This function was renamed to `get_current_message()`.

If the function fails, that means that there was no message on this topic, we we continue to the next topic.