### PR TITLE
logging INFO CYAN instead of BLUE

### DIFF
--- a/catkit2/testbed/logging.py
+++ b/catkit2/testbed/logging.py
@@ -144,7 +144,7 @@ class LogTerminal(LogObserver):
         self.level = Severity.WARNING
         self.colors = {
             Severity.DEBUG: Fore.GREEN,
-            Severity.INFO: Fore.BLUE,
+            Severity.INFO: Fore.CYAN,
             Severity.WARNING: Fore.YELLOW,
             Severity.ERROR: Fore.RED,
             Severity.CRITICAL: Fore.WHITE + Back.RED


### PR DESCRIPTION
Fixes #354 

BLUE logging info is hard to see in dark mode terminals, however CYAN works well with dark or light mode terminals. 