### PR TITLE
Add power function mode to Thorlabs CLD laser diodes

### DIFF
--- a/catkit2/services/thorlabs_cld101x/thorlabs_cld101x.py
+++ b/catkit2/services/thorlabs_cld101x/thorlabs_cld101x.py
@@ -13,6 +13,7 @@ class ThorlabsCLD101X(Service):
 
         self.visa_id = self.config['visa_id']
         self.wavelength = self.config['wavelength']
+        self.max_current = self.config['max_current']   # in Ampere
 
         self.current_setpoint = self.make_data_stream(f'current_setpoint_{self.wavelength}', 'float32', [1], 20)
         self.current_percent = self.make_data_stream(f'current_percent_{self.wavelength}', 'float32', [1], 20)
@@ -32,9 +33,6 @@ class ThorlabsCLD101X(Service):
         self.connection.write("output1:state on")
         self.connection.write(f"{self._SET_CURRENT}0.0")
         self.current_percent.submit_data(np.array([0.0], dtype='float32'))
-
-        # Read max current setpoint.
-        self.max_current = float(self.connection.query('source1:current:limit:amplitude?'))  # in Ampere
 
     def main(self):
         while not self.should_shut_down:

--- a/catkit2/services/thorlabs_cld101x/thorlabs_cld101x.py
+++ b/catkit2/services/thorlabs_cld101x/thorlabs_cld101x.py
@@ -10,7 +10,7 @@ class ThorlabsCLD101X(Service):
 
         self.visa_id = self.config['visa_id']
         self.wavelength = self.config['wavelength']
-        self.function_mode= self.config['function_mode']  # 'current' or 'power'
+        self.function_mode = self.config['function_mode']  # 'current' or 'power'
         self.max_current = self.config['max_current']  # in Ampere
 
         if self.function_mode == 'current':

--- a/catkit2/services/thorlabs_cld101x/thorlabs_cld101x.py
+++ b/catkit2/services/thorlabs_cld101x/thorlabs_cld101x.py
@@ -5,15 +5,20 @@ import numpy as np
 
 
 class ThorlabsCLD101X(Service):
-    _GET_CURRENT = "source1:current:level:amplitude?"
-    _SET_CURRENT = "source1:current:level:amplitude "
-
     def __init__(self):
         super().__init__('thorlabs_cld101x')
 
         self.visa_id = self.config['visa_id']
         self.wavelength = self.config['wavelength']
-        self.max_current = self.config['max_current']   # in Ampere
+        self.function_mode= self.config['function_mode']  # 'current' or 'power'
+        self.max_current = self.config['max_current']  # in Ampere
+
+        if self.function_mode == 'current':
+            self.get_current = 'source1:current:level:amplitude?'
+            self.set_current = 'source1:current:level:amplitude '
+        elif self.function_mode == 'power':
+            self.get_current = 'source1:power:level:diode:amplitude?'  # TODO: check if this is correct
+            self.set_current = 'source1:power:level:diode:amplitude '  # TODO: check if this is correct
 
         self.current_setpoint = self.make_data_stream(f'current_setpoint_{self.wavelength}', 'float32', [1], 20)
         self.current_percent = self.make_data_stream(f'current_percent_{self.wavelength}', 'float32', [1], 20)
@@ -26,12 +31,12 @@ class ThorlabsCLD101X(Service):
         self.connection.write('*RST')
         self.connection.write('output2:state on')
 
-        # Set to constant current mode.
-        self.connection.write('source1:function:mode current')
+        # Set function mode.
+        self.connection.write(f'source1:function:mode {self.function_mode}')
 
         # Turn laser on and set current setpoint to 0.0
         self.connection.write("output1:state on")
-        self.connection.write(f"{self._SET_CURRENT}0.0")
+        self.connection.write(f"{self.set_current}0.0")
         self.current_percent.submit_data(np.array([0.0], dtype='float32'))
 
     def main(self):
@@ -47,7 +52,7 @@ class ThorlabsCLD101X(Service):
                 continue
 
     def close(self):
-        self.connection.write(f"{self._SET_CURRENT}0.0")
+        self.connection.write(f"{self.set_current}0.0")
         self.connection.write("output1:state off")
         self.connection.write("output2:state off")
         self.connection.close()
@@ -68,7 +73,7 @@ class ThorlabsCLD101X(Service):
             raise ValueError("Current_percent must be between 0 and 100.")
 
         current_setpoint = current_percent / 100 * self.max_current
-        self.connection.write(f"{self._SET_CURRENT}{current_setpoint}")
+        self.connection.write(f"{self.set_current}{current_setpoint}")
 
         self.current_setpoint.submit_data(np.array([current_setpoint], dtype='float32'))
 

--- a/catkit2/services/thorlabs_cld101x/thorlabs_cld101x.py
+++ b/catkit2/services/thorlabs_cld101x/thorlabs_cld101x.py
@@ -17,8 +17,8 @@ class ThorlabsCLD101X(Service):
             self.get_current = 'source1:current:level:amplitude?'
             self.set_current = 'source1:current:level:amplitude '
         elif self.function_mode == 'power':
-            self.get_current = 'source1:power:level:diode:amplitude?'  # TODO: check if this is correct
-            self.set_current = 'source1:power:level:diode:amplitude '  # TODO: check if this is correct
+            self.get_current = 'source1:power:level:diode:amplitude?'
+            self.set_current = 'source1:power:level:diode:amplitude '
 
         self.current_setpoint = self.make_data_stream(f'current_setpoint_{self.wavelength}', 'float32', [1], 20)
         self.current_percent = self.make_data_stream(f'current_percent_{self.wavelength}', 'float32', [1], 20)


### PR DESCRIPTION
Previously, we could only use this service to control a CLD by controlling the LD current. This PR adds the option to control the the LD power by controlling the photodiode current instead.

Software docs:
https://www.thorlabs.com/drawings/3d9d377a333d5fcc-242A96AC-CDBB-1019-3464EF2B8B26961B/CLD1015-ProgrammersReferenceManual.pdf

And specifically:
![Screenshot 2025-07-03 at 19 35 06](https://github.com/user-attachments/assets/28ac38e5-e702-4dc2-9834-dc550501148f)
