### PR TITLE
Hamamatsu temperature safety

### DIFF
--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -303,8 +303,8 @@ class HamamatsuCamera(Service):
             temperature = self.get_temperature()
             self.temperature.submit_data(np.array([temperature]))
 
-            if temperature > self.critical_temp and self.is_acquiring.get():
-                self.log.warning(f'Camera temperature = {temperature} > {self.critical_temp} degrees.')
+            if temperature > self.critical_temperature and self.is_acquiring.get():
+                self.log.warning(f'Camera temperature = {temperature} > {self.critical_temperature} degrees.')
                 self.log.warning('Stopping acquisition and start fan.')
                 self.fan_status = True
                 self.cooler_mode = 'on'

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -311,7 +311,7 @@ class HamamatsuCamera(Service):
     def cooler_mode(self):
         """
         Check the cooling mode
-        
+
         Returns
         -------
         coolstr:
@@ -324,7 +324,7 @@ class HamamatsuCamera(Service):
             return 'off'
         elif coolint == 2.0:
             return 'on'
-        else :
+        else:
             return 'max'
 
     @cooler_mode.setter
@@ -353,7 +353,7 @@ class HamamatsuCamera(Service):
     def fan_status(self):
         """
         Check fan status
-        
+
         Returns
         -------
         onoff: bool

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -63,9 +63,9 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
                 if hamamatsu_property_name == 'EXPOSURETIME':
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value / 1e6)
                 elif hamamatsu_property_name == 'SENSORCOOLER':
-                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), CoolerMode(value).value)
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), CoolerMode[value].value)
                 elif hamamatsu_property_name == 'SENSORCOOLERFAN':
-                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), FanStatus(value).value)
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), FanStatus[value].value)
                 else:
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value)
 

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -216,6 +216,8 @@ class HamamatsuCamera(Service):
         self.make_command('start_acquisition', self.start_acquisition)
         self.make_command('end_acquisition', self.end_acquisition)
 
+        self.critical_temp = self.config.get('critical_temp', 27.0)
+
         # Set water cooling mode and fan mode
         self.cooler_mode = self.config.get('cooling_mode', 'on')
 
@@ -301,8 +303,9 @@ class HamamatsuCamera(Service):
             temperature = self.get_temperature()
             self.temperature.submit_data(np.array([temperature]))
 
-            if temperature > 27 and self.is_acquiring.get() :
-                self.log.warning(f'Camera Temperature {temperature} > 27 degrees, stopping acquisition and start fan')
+            if temperature > self.critical_temp and self.is_acquiring.get() :
+                self.log.warning(f'Camera temperature = {temperature} > {self.critical_temp} degrees.')
+                self.log.warning('Stopping acquisition and start fan.')
                 self.fan_status = True
                 self.cooler_mode = 'on'
                 self.end_acquisition()

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -22,36 +22,6 @@ except ImportError:
     print('To use Hamamatsu cameras, you need to set the CATKIT_DCAM_SDK_PATH environment variable.')
     raise
 
-def cooler_mode_string2int(coolstr):
-        if coolstr == 'off':
-            return 1.0
-        elif coolstr == 'on':
-            return 2.0  # target temperature = -20 deg
-        elif coolstr == 'max':
-            return 4.0  # target temperature = -31 deg
-        else:
-            raise ValueError('Not recognized in water cooling mode.')
-
-def cooler_mode_int2string(coolint):
-        if coolint == 1.0:
-            return 'off'
-        elif coolint == 2.0:
-            return 'on'  # target temperature = -20 deg
-        else:
-            return 'max'  # target temperature = -31 deg
-
-def fan_status_bool2int(onoff):
-        if onoff:
-            return 2.0
-        else:
-            return 1.0
-
-def fan_status_int2bool(onoffint):
-        if onoffint == 1.0:
-            return False
-        elif onoffint == 2.0:
-            return True
-
 
 def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisition=True):
     def getter(self):
@@ -60,10 +30,6 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
                 return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)) * 1e6
             elif hamamatsu_property_name in ['SUBARRAYHSIZE', 'SUBARRAYVSIZE', 'SUBARRAYVPOS', 'SUBARRAYHPOS']:
                 return int(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
-            elif hamamatsu_property_name == 'SENSORCOOLER':
-                return cooler_mode_int2string(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
-            elif hamamatsu_property_name == 'SENSORCOOLERFAN':
-                return fan_status_int2bool(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
             else:
                 return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))
 
@@ -237,18 +203,19 @@ class HamamatsuCamera(Service):
         self.temperature = self.make_data_stream('temperature', 'float64', [1], 20)
 
         make_property_helper('exposure_time')
-        make_property_helper('gain', read_only=True)
-        make_property_helper('brightness', read_only=True)
 
         make_property_helper('width')
         make_property_helper('height')
         make_property_helper('offset_x')
         make_property_helper('offset_y')
-        make_property_helper('sensor_width', read_only=True)
-        make_property_helper('sensor_height', read_only=True)
 
+        make_property_helper('gain', read_only=True)
+        make_property_helper('brightness', read_only=True)
         make_property_helper('fan_status')
         make_property_helper('cooler_mode')
+
+        make_property_helper('sensor_width', read_only=True)
+        make_property_helper('sensor_height', read_only=True)
 
         self.make_command('start_acquisition', self.start_acquisition)
         self.make_command('end_acquisition', self.end_acquisition)
@@ -349,6 +316,82 @@ class HamamatsuCamera(Service):
 
             self.sleep(0.1)
 
+    @property
+    def cooler_mode(self):
+        """
+        Check the cooling mode.
+
+        Returns
+        -------
+        str :
+            Sensor cooler status 'on', 'off' or 'max'.
+        """
+        coolint = self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSORCOOLER)
+
+        if coolint == 1.0:
+            return 'off'
+        elif coolint == 2.0:
+            return 'on'  # target temperature = -20 deg
+        else:
+            return 'max'  # target temperature = -31 deg
+
+    @cooler_mode.setter
+    def cooler_mode(self, coolstr):
+        """
+        Set the cooling mode.
+
+        Parameters
+        ----------
+        coolstr : str
+            Cooling mode of the camera.
+        """
+
+        if coolstr == 'off':
+            coolint = 1.0
+        elif coolstr == 'on':
+            coolint = 2.0
+        elif coolstr == 'max':
+            coolint = 4.0
+        else:
+            raise ValueError('Water cooling mode not recognized.')
+
+        self.cam.prop_setvalue(dcam.DCAM_IDPROP.SENSORCOOLER, coolint)
+
+    @property
+    def fan_status(self):
+        """
+        Check fan status
+
+        Returns
+        -------
+        bool :
+            Fan status True or False.
+        """
+        onoffint = self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSORCOOLERFAN)
+
+        if onoffint == 1.0:
+            return False
+        elif onoffint == 2.0:
+            return True
+
+    @fan_status.setter
+    def fan_status(self, onoff=True):
+        """
+        Start / stop the the camera fan.
+
+        Parameters
+        ----------
+        onoff : bool
+            True or False to start or stop the fan.
+        """
+
+        if onoff:
+            onoffint = 2.0
+        else:
+            onoffint = 1.0
+
+        self.cam.prop_setvalue(dcam.DCAM_IDPROP.SENSORCOOLERFAN, onoffint)
+
     def start_acquisition(self):
         """
         Start the acquisition loop.
@@ -366,9 +409,6 @@ class HamamatsuCamera(Service):
         self.should_be_acquiring.clear()
 
     exposure_time = _create_property('EXPOSURETIME', stopped_acquisition=False)
-
-    cooler_mode = _create_property('SENSORCOOLER', stopped_acquisition=False)
-    fan_status = _create_property('SENSORCOOLERFAN', stopped_acquisition=False)
 
     width = _create_property('SUBARRAYHSIZE')
     height = _create_property('SUBARRAYVSIZE')

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -216,9 +216,9 @@ class HamamatsuCamera(Service):
         self.make_command('start_acquisition', self.start_acquisition)
         self.make_command('end_acquisition', self.end_acquisition)
 
-        self.critical_temp = self.config.get('critical_temp', 27.0)
+        self.critical_temperature = self.config.get('critical_temperature', 28.0)
 
-        # Set water cooling mode and fan mode
+        # Set water cooling mode
         self.cooler_mode = self.config.get('cooling_mode', 'on')
 
         # check fan status and start / stop fan
@@ -327,9 +327,9 @@ class HamamatsuCamera(Service):
         if coolint == 1.0:
             return 'off'
         elif coolint == 2.0:
-            return 'on'
+            return 'on'  # target temperature = -20 deg
         else:
-            return 'max'
+            return 'max'  # target temperature = -31 deg
 
     @cooler_mode.setter
     def cooler_mode(self, coolstr):
@@ -367,7 +367,7 @@ class HamamatsuCamera(Service):
 
         if onoffint == 1.0:
             return False
-        if onoffint == 2.0:
+        elif onoffint == 2.0:
             return True
 
     @fan_status.setter

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -81,9 +81,9 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
             with self.mutex:
                 if hamamatsu_property_name == 'EXPOSURETIME':
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value / 1e6)
-                if hamamatsu_property_name == 'SENSORCOOLER':
+                elif hamamatsu_property_name == 'SENSORCOOLER':
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), cooler_mode_string2int(value))
-                if hamamatsu_property_name == 'SENSORCOOLERFAN':
+                elif hamamatsu_property_name == 'SENSORCOOLERFAN':
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), fan_status_bool2int(value))
                 else:
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value)

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -301,8 +301,9 @@ class HamamatsuCamera(Service):
             self.temperature.submit_data(np.array([temperature]))
 
             if temperature > 30:
-                self.log.warning('Camera Temperature above 30 degrees, stopping acquisition and start fan')
-                self.fan_status = 'on'
+                self.log.warning('Camera Temperature above 30 degrees, stopping camera service and start fan')
+                self.fan_status = True
+                self.cooler_mode = 'on'
                 self.should_shut_down = True
 
             self.sleep(0.1)
@@ -310,13 +311,12 @@ class HamamatsuCamera(Service):
     @property
     def cooler_mode(self):
         """
-        Check the cooling mode
+        Check the cooling mode.
 
         Returns
         -------
-        coolstr:
-            sensor cooler status 'on', 'off' or 'max'
-
+        str :
+            Sensor cooler status 'on', 'off' or 'max'.
         """
         coolint = self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSORCOOLER)
 
@@ -330,12 +330,12 @@ class HamamatsuCamera(Service):
     @cooler_mode.setter
     def cooler_mode(self, coolstr):
         """
-        Set the cooling mode
+        Set the cooling mode.
 
-        Parameterss
+        Parameters
         ----------
         coolstr : str
-            Cooling mode of the camera
+            Cooling mode of the camera.
         """
 
         if coolstr == 'off':
@@ -356,8 +356,8 @@ class HamamatsuCamera(Service):
 
         Returns
         -------
-        onoff: bool
-            Fan status True or False
+        bool :
+            Fan status True or False.
         """
         onoffint = self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSORCOOLERFAN)
 
@@ -369,18 +369,18 @@ class HamamatsuCamera(Service):
     @fan_status.setter
     def fan_status(self, onoff=True):
         """
-        Start / stop the the camera fan
+        Start / stop the the camera fan.
 
-        Parameterss
+        Parameters
         ----------
         onoff : bool
-            True or False to start or stop the fan
+            True or False to start or stop the fan.
         """
 
-        if not onoff:
-            onoffint = 1.0
-        else:
+        if  onoff:
             onoffint = 2.0
+        else:
+            onoffint = 1.0
 
         self.cam.prop_setvalue(dcam.DCAM_IDPROP.SENSORCOOLERFAN, onoffint)
 

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -226,6 +226,8 @@ class HamamatsuCamera(Service):
 
         make_property_helper('gain', read_only=True)
         make_property_helper('brightness', read_only=True)
+        make_property_helper('fan_status')
+        make_property_helper('sensor_cooler')
         make_property_helper('sensor_width', read_only=True)
         make_property_helper('sensor_height', read_only=True)
 
@@ -311,6 +313,55 @@ class HamamatsuCamera(Service):
             self.temperature.submit_data(np.array([temperature]))
 
             self.sleep(0.1)
+
+
+
+    @property
+    def sensor_cooler(self):
+        """
+        Start the fan
+
+        """
+        return self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSORCOOLER)
+
+    @sensor_cooler.setter
+    def sensor_cooler(self, number):
+        """
+        Start the fan
+
+        """
+        self.cam.prop_setvalue(dcam.DCAM_IDPROP.SENSORCOOLER, number)
+    @property
+    def sensor_cooler_status(self):
+        """
+        Start the fan
+
+        """
+        return self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSORCOOLERSTATUS)
+    @property
+    def sensor_temperature_status(self):
+        """
+        Start the fan
+
+        """
+        return self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSORTEMPERATURE_STATUS)
+
+
+    @property
+    def fan_status(self):
+        """
+        Start the fan
+
+        """
+        return self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSORCOOLERFAN)
+    @fan_status.setter
+    def fan_status(self, onoff):
+        """
+        Start the fan
+
+        """
+        self.cam.prop_setvalue(dcam.DCAM_IDPROP.SENSORCOOLERFAN, onoff)
+
 
     def start_acquisition(self):
         """

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -52,7 +52,6 @@ def fan_status_int2bool(onoffint):
         elif onoffint == 2.0:
             return True
 
-
 def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisition=True):
     def getter(self):
         with self.mutex:
@@ -85,7 +84,7 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
                 if hamamatsu_property_name == 'SENSORCOOLER':
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), cooler_mode_string2int(value))
                 if hamamatsu_property_name == 'SENSORCOOLERFAN':
-                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), cooler_mode_int2string(value))
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), fan_status_bool2int(value))
                 else:
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value)
             if was_running and stopped_acquisition:
@@ -175,6 +174,7 @@ class HamamatsuCamera(Service):
         # Read ROI of full sensor before ROI is adapted.
         self.sensor_width = int(self.cam.prop_getvalue(dcam.DCAM_IDPROP.IMAGE_WIDTH))
         self.sensor_height = int(self.cam.prop_getvalue(dcam.DCAM_IDPROP.IMAGE_HEIGHT))
+
         # Set subarray mode to on so that it checks subarray compatibility when picking ROI
         self.cam.prop_setvalue(dcam.DCAM_IDPROP.SUBARRAYMODE, 2.0)
 

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -237,6 +237,7 @@ class HamamatsuCamera(Service):
                 self.acquisition_loop()
 
     def close(self):
+        self.cooler_mode = 'on'
         self.cam.dev_close()
         self.cam = None
 
@@ -300,11 +301,11 @@ class HamamatsuCamera(Service):
             temperature = self.get_temperature()
             self.temperature.submit_data(np.array([temperature]))
 
-            if temperature > 30:
-                self.log.warning('Camera Temperature above 30 degrees, stopping camera service and start fan')
+            if temperature > 27 and self.is_acquiring.get() :
+                self.log.warning(f'Camera Temperature {temperature} > 27 degrees, stopping acquisition and start fan')
                 self.fan_status = True
                 self.cooler_mode = 'on'
-                self.should_shut_down = True
+                self.end_acquisition()
 
             self.sleep(0.1)
 

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -22,6 +22,36 @@ except ImportError:
     print('To use Hamamatsu cameras, you need to set the CATKIT_DCAM_SDK_PATH environment variable.')
     raise
 
+def cooler_mode_string2int(coolstr):
+        if coolstr == 'off':
+            return 1.0
+        elif coolstr == 'on':
+            return 2.0  # target temperature = -20 deg
+        elif coolstr == 'max':
+            return 4.0  # target temperature = -31 deg
+        else:
+            raise ValueError('Not recognized in water cooling mode.')
+
+def cooler_mode_int2string(coolint):
+        if coolint == 1.0:
+            return 'off'
+        elif coolint == 2.0:
+            return 'on'  # target temperature = -20 deg
+        else:
+            return 'max'  # target temperature = -31 deg
+
+def fan_status_bool2int(onoff):
+        if onoff:
+            return 2.0
+        else:
+            return 1.0
+
+def fan_status_int2bool(onoffint):
+        if onoffint == 1.0:
+            return False
+        elif onoffint == 2.0:
+            return True
+
 
 def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisition=True):
     def getter(self):
@@ -30,6 +60,10 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
                 return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)) * 1e6
             elif hamamatsu_property_name in ['SUBARRAYHSIZE', 'SUBARRAYVSIZE', 'SUBARRAYVPOS', 'SUBARRAYHPOS']:
                 return int(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
+            elif hamamatsu_property_name == 'SENSORCOOLER':
+                return cooler_mode_int2string(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
+            elif hamamatsu_property_name == 'SENSORCOOLERFAN':
+                return fan_status_int2bool(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
             else:
                 return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))
 
@@ -203,19 +237,18 @@ class HamamatsuCamera(Service):
         self.temperature = self.make_data_stream('temperature', 'float64', [1], 20)
 
         make_property_helper('exposure_time')
+        make_property_helper('gain', read_only=True)
+        make_property_helper('brightness', read_only=True)
 
         make_property_helper('width')
         make_property_helper('height')
         make_property_helper('offset_x')
         make_property_helper('offset_y')
-
-        make_property_helper('gain', read_only=True)
-        make_property_helper('brightness', read_only=True)
-        make_property_helper('fan_status')
-        make_property_helper('cooler_mode')
-
         make_property_helper('sensor_width', read_only=True)
         make_property_helper('sensor_height', read_only=True)
+
+        make_property_helper('fan_status')
+        make_property_helper('cooler_mode')
 
         self.make_command('start_acquisition', self.start_acquisition)
         self.make_command('end_acquisition', self.end_acquisition)
@@ -316,82 +349,6 @@ class HamamatsuCamera(Service):
 
             self.sleep(0.1)
 
-    @property
-    def cooler_mode(self):
-        """
-        Check the cooling mode.
-
-        Returns
-        -------
-        str :
-            Sensor cooler status 'on', 'off' or 'max'.
-        """
-        coolint = self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSORCOOLER)
-
-        if coolint == 1.0:
-            return 'off'
-        elif coolint == 2.0:
-            return 'on'  # target temperature = -20 deg
-        else:
-            return 'max'  # target temperature = -31 deg
-
-    @cooler_mode.setter
-    def cooler_mode(self, coolstr):
-        """
-        Set the cooling mode.
-
-        Parameters
-        ----------
-        coolstr : str
-            Cooling mode of the camera.
-        """
-
-        if coolstr == 'off':
-            coolint = 1.0
-        elif coolstr == 'on':
-            coolint = 2.0
-        elif coolstr == 'max':
-            coolint = 4.0
-        else:
-            raise ValueError('Water cooling mode not recognized.')
-
-        self.cam.prop_setvalue(dcam.DCAM_IDPROP.SENSORCOOLER, coolint)
-
-    @property
-    def fan_status(self):
-        """
-        Check fan status
-
-        Returns
-        -------
-        bool :
-            Fan status True or False.
-        """
-        onoffint = self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSORCOOLERFAN)
-
-        if onoffint == 1.0:
-            return False
-        elif onoffint == 2.0:
-            return True
-
-    @fan_status.setter
-    def fan_status(self, onoff=True):
-        """
-        Start / stop the the camera fan.
-
-        Parameters
-        ----------
-        onoff : bool
-            True or False to start or stop the fan.
-        """
-
-        if onoff:
-            onoffint = 2.0
-        else:
-            onoffint = 1.0
-
-        self.cam.prop_setvalue(dcam.DCAM_IDPROP.SENSORCOOLERFAN, onoffint)
-
     def start_acquisition(self):
         """
         Start the acquisition loop.
@@ -409,6 +366,9 @@ class HamamatsuCamera(Service):
         self.should_be_acquiring.clear()
 
     exposure_time = _create_property('EXPOSURETIME', stopped_acquisition=False)
+
+    cooler_mode = _create_property('SENSORCOOLER', stopped_acquisition=False)
+    fan_status = _create_property('SENSORCOOLERFAN', stopped_acquisition=False)
 
     width = _create_property('SUBARRAYHSIZE')
     height = _create_property('SUBARRAYVSIZE')

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -40,17 +40,21 @@ class CoolerMode(Enum):
         return self.name.lower()
 
 
-def fan_status_bool2int(onoff):
-        if onoff:
-            return 2.0
-        else:
-            return 1.0
+class FanStatus(Enum):
+    OFF = 1.0
+    ON = 2.0
 
-def fan_status_int2bool(onoffint):
-        if onoffint == 1.0:
-            return False
-        elif onoffint == 2.0:
-            return True
+    @classmethod
+    def from_bool(cls, val):
+        return cls.ON if val else cls.OFF
+
+    @classmethod
+    def from_int(cls, val):
+        return cls(val)
+
+    def to_bool(self):
+        return self is FanStatus.ON
+
 
 def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisition=True):
     def getter(self):
@@ -62,7 +66,7 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
             elif hamamatsu_property_name == 'SENSORCOOLER':
                 return str(CoolerMode(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))))
             elif hamamatsu_property_name == 'SENSORCOOLERFAN':
-                return fan_status_int2bool(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
+                return FanStatus.from_int(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)).to_bool())
             else:
                 return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))
 
@@ -84,9 +88,10 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
                 elif hamamatsu_property_name == 'SENSORCOOLER':
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), CoolerMode.from_string(value).value)
                 elif hamamatsu_property_name == 'SENSORCOOLERFAN':
-                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), fan_status_bool2int(value))
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), FanStatus.from_bool(value).value)
                 else:
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value)
+
             if was_running and stopped_acquisition:
                 self.start_acquisition()
 

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -25,36 +25,13 @@ except ImportError:
 
 
 class CoolerMode(Enum):
-    OFF = 1.0
-    ON = 2.0    # target temperature = -20 deg
-    MAX = 4.0   # target temperature = -31 deg
-
-    @classmethod
-    def from_string(cls, coolstr):
-        try:
-            return cls[coolstr.upper()]
-        except KeyError:
-            raise ValueError('Water cooling mode not recognized.')
-
-    def __str__(self):
-        return self.name.lower()
-
+    off = 1.0
+    on = 2.0    # target temperature = -20 deg
+    max = 4.0   # target temperature = -31 deg
 
 class FanStatus(Enum):
-    OFF = 1.0
-    ON = 2.0
-
-    @classmethod
-    def from_bool(cls, val):
-        return cls.ON if val else cls.OFF
-
-    @classmethod
-    def from_int(cls, val):
-        return cls(val)
-
-    def to_bool(self):
-        return self is FanStatus.ON
-
+    off = 1.0
+    on = 2.0
 
 def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisition=True):
     def getter(self):
@@ -64,9 +41,9 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
             elif hamamatsu_property_name in ['SUBARRAYHSIZE', 'SUBARRAYVSIZE', 'SUBARRAYVPOS', 'SUBARRAYHPOS']:
                 return int(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
             elif hamamatsu_property_name == 'SENSORCOOLER':
-                return str(CoolerMode(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))))
+                return CoolerMode(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))).name
             elif hamamatsu_property_name == 'SENSORCOOLERFAN':
-                return FanStatus.from_int(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)).to_bool())
+                return FanStatus(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))).name
             else:
                 return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))
 
@@ -86,9 +63,9 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
                 if hamamatsu_property_name == 'EXPOSURETIME':
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value / 1e6)
                 elif hamamatsu_property_name == 'SENSORCOOLER':
-                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), CoolerMode.from_string(value).value)
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), CoolerMode(value).value)
                 elif hamamatsu_property_name == 'SENSORCOOLERFAN':
-                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), FanStatus.from_bool(value).value)
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), FanStatus(value).value)
                 else:
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value)
 
@@ -264,7 +241,7 @@ class HamamatsuCamera(Service):
         self.cooler_mode = self.config.get('cooling_mode', 'on')
 
         # check fan status and start / stop fan
-        self.fan_status = self.config.get('fan_on', True)
+        self.fan_status = self.config.get('fan_status', 'off')
 
         self.temperature_thread = threading.Thread(target=self.monitor_temperature)
         self.temperature_thread.start()
@@ -348,7 +325,7 @@ class HamamatsuCamera(Service):
             if temperature > self.critical_temperature and self.is_acquiring.get():
                 self.log.warning(f'Camera temperature = {temperature} > {self.critical_temperature} degrees.')
                 self.log.warning('Stopping acquisition and start fan.')
-                self.fan_status = True
+                self.fan_status = 'on'
                 self.cooler_mode = 'on'
                 self.end_acquisition()
 

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -303,7 +303,7 @@ class HamamatsuCamera(Service):
             temperature = self.get_temperature()
             self.temperature.submit_data(np.array([temperature]))
 
-            if temperature > self.critical_temp and self.is_acquiring.get() :
+            if temperature > self.critical_temp and self.is_acquiring.get():
                 self.log.warning(f'Camera temperature = {temperature} > {self.critical_temp} degrees.')
                 self.log.warning('Stopping acquisition and start fan.')
                 self.fan_status = True
@@ -381,7 +381,7 @@ class HamamatsuCamera(Service):
             True or False to start or stop the fan.
         """
 
-        if  onoff:
+        if onoff:
             onoffint = 2.0
         else:
             onoffint = 1.0

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -137,25 +137,6 @@ class HamamatsuCamera(Service):
         # Read ROI of full sensor before ROI is adapted.
         self.sensor_width = int(self.cam.prop_getvalue(dcam.DCAM_IDPROP.IMAGE_WIDTH))
         self.sensor_height = int(self.cam.prop_getvalue(dcam.DCAM_IDPROP.IMAGE_HEIGHT))
-
-        # Set water cooling mode and fan mode
-        self.cooling_mode = self.config.get('cooling_mode', 'on')
-        self.fan_on = self.config.get('fan_on', True)
-
-        fan = 2.0 if self.fan_on else 1.0
-        self.cam.prop_setvalue(dcam.DCAM_IDPROP.SENSORCOOLERFAN, fan)
-
-        if self.cooling_mode == 'off':
-            cool = 1.0
-        elif self.cooling_mode == 'on':
-            cool = 2.0
-        elif self.cooling_mode == 'max':
-            cool = 4.0
-        else:
-            raise ValueError('Water cooling mode not recognized.')
-
-        self.cam.prop_setvalue(dcam.DCAM_IDPROP.SENSORCOOLER, cool)
-
         # Set subarray mode to on so that it checks subarray compatibility when picking ROI
         self.cam.prop_setvalue(dcam.DCAM_IDPROP.SUBARRAYMODE, 2.0)
 
@@ -227,12 +208,19 @@ class HamamatsuCamera(Service):
         make_property_helper('gain', read_only=True)
         make_property_helper('brightness', read_only=True)
         make_property_helper('fan_status')
-        make_property_helper('sensor_cooler')
+        make_property_helper('cooler_mode')
+
         make_property_helper('sensor_width', read_only=True)
         make_property_helper('sensor_height', read_only=True)
 
         self.make_command('start_acquisition', self.start_acquisition)
         self.make_command('end_acquisition', self.end_acquisition)
+
+        # Set water cooling mode and fan mode
+        self.cooler_mode = self.config.get('cooling_mode', 'on')
+
+        # check fan status and start / stop fan
+        self.fan_status = self.config.get('fan_on', True)
 
         self.temperature_thread = threading.Thread(target=self.monitor_temperature)
         self.temperature_thread.start()
@@ -312,56 +300,89 @@ class HamamatsuCamera(Service):
             temperature = self.get_temperature()
             self.temperature.submit_data(np.array([temperature]))
 
+            if temperature > 30:
+                self.log.warning('Camera Temperature above 30 degrees, stopping acquisition and start fan')
+                self.fan_status = 'on'
+                self.should_shut_down = True
+
             self.sleep(0.1)
 
-
-
     @property
-    def sensor_cooler(self):
+    def cooler_mode(self):
         """
-        Start the fan
+        Check the cooling mode
+        
+        Returns
+        -------
+        coolstr:
+            sensor cooler status 'on', 'off' or 'max'
 
         """
-        return self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSORCOOLER)
+        coolint = self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSORCOOLER)
 
-    @sensor_cooler.setter
-    def sensor_cooler(self, number):
-        """
-        Start the fan
+        if coolint == 1.0:
+            return 'off'
+        elif coolint == 2.0:
+            return 'on'
+        else :
+            return 'max'
 
+    @cooler_mode.setter
+    def cooler_mode(self, coolstr):
         """
-        self.cam.prop_setvalue(dcam.DCAM_IDPROP.SENSORCOOLER, number)
-    @property
-    def sensor_cooler_status(self):
-        """
-        Start the fan
+        Set the cooling mode
 
+        Parameterss
+        ----------
+        coolstr : str
+            Cooling mode of the camera
         """
-        return self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSORCOOLERSTATUS)
-    @property
-    def sensor_temperature_status(self):
-        """
-        Start the fan
 
-        """
-        return self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSORTEMPERATURE_STATUS)
+        if coolstr == 'off':
+            coolint = 1.0
+        elif coolstr == 'on':
+            coolint = 2.0
+        elif coolstr == 'max':
+            coolint = 4.0
+        else:
+            raise ValueError('Water cooling mode not recognized.')
 
+        self.cam.prop_setvalue(dcam.DCAM_IDPROP.SENSORCOOLER, coolint)
 
     @property
     def fan_status(self):
         """
-        Start the fan
-
+        Check fan status
+        
+        Returns
+        -------
+        onoff: bool
+            Fan status True or False
         """
-        return self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSORCOOLERFAN)
+        onoffint = self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSORCOOLERFAN)
+
+        if onoffint == 1.0:
+            return False
+        if onoffint == 2.0:
+            return True
+
     @fan_status.setter
-    def fan_status(self, onoff):
+    def fan_status(self, onoff=True):
         """
-        Start the fan
+        Start / stop the the camera fan
 
+        Parameterss
+        ----------
+        onoff : bool
+            True or False to start or stop the fan
         """
-        self.cam.prop_setvalue(dcam.DCAM_IDPROP.SENSORCOOLERFAN, onoff)
 
+        if not onoff:
+            onoffint = 1.0
+        else:
+            onoffint = 2.0
+
+        self.cam.prop_setvalue(dcam.DCAM_IDPROP.SENSORCOOLERFAN, onoffint)
 
     def start_acquisition(self):
         """

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -4,6 +4,7 @@ This module contains a service for Hamamatsu digital cameras.
 This service is a wrapper around the DCAM-SDK4.
 It provides a simple interface to control the camera and acquire images.
 """
+from enum import Enum
 import os
 import sys
 import threading
@@ -22,23 +23,22 @@ except ImportError:
     print('To use Hamamatsu cameras, you need to set the CATKIT_DCAM_SDK_PATH environment variable.')
     raise
 
-def cooler_mode_string2int(coolstr):
-        if coolstr == 'off':
-            return 1.0
-        elif coolstr == 'on':
-            return 2.0  # target temperature = -20 deg
-        elif coolstr == 'max':
-            return 4.0  # target temperature = -31 deg
-        else:
-            raise ValueError('Not recognized in water cooling mode.')
 
-def cooler_mode_int2string(coolint):
-        if coolint == 1.0:
-            return 'off'
-        elif coolint == 2.0:
-            return 'on'  # target temperature = -20 deg
-        else:
-            return 'max'  # target temperature = -31 deg
+class CoolerMode(Enum):
+    OFF = 1.0
+    ON = 2.0    # target temperature = -20 deg
+    MAX = 4.0   # target temperature = -31 deg
+
+    @classmethod
+    def from_string(cls, coolstr):
+        try:
+            return cls[coolstr.upper()]
+        except KeyError:
+            raise ValueError('Water cooling mode not recognized.')
+
+    def __str__(self):
+        return self.name.lower()
+
 
 def fan_status_bool2int(onoff):
         if onoff:
@@ -60,7 +60,7 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
             elif hamamatsu_property_name in ['SUBARRAYHSIZE', 'SUBARRAYVSIZE', 'SUBARRAYVPOS', 'SUBARRAYHPOS']:
                 return int(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
             elif hamamatsu_property_name == 'SENSORCOOLER':
-                return cooler_mode_int2string(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
+                return str(CoolerMode(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))))
             elif hamamatsu_property_name == 'SENSORCOOLERFAN':
                 return fan_status_int2bool(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
             else:
@@ -82,7 +82,7 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
                 if hamamatsu_property_name == 'EXPOSURETIME':
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value / 1e6)
                 elif hamamatsu_property_name == 'SENSORCOOLER':
-                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), cooler_mode_string2int(value))
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), CoolerMode.from_string(value).value)
                 elif hamamatsu_property_name == 'SENSORCOOLERFAN':
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), fan_status_bool2int(value))
                 else:

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -22,6 +22,36 @@ except ImportError:
     print('To use Hamamatsu cameras, you need to set the CATKIT_DCAM_SDK_PATH environment variable.')
     raise
 
+def cooler_mode_string2int(coolstr):
+        if coolstr == 'off':
+            return 1.0
+        elif coolstr == 'on':
+            return 2.0  # target temperature = -20 deg
+        elif coolstr == 'max':
+            return 4.0  # target temperature = -31 deg
+        else:
+            raise ValueError('Not recognized in water cooling mode.')
+
+def cooler_mode_int2string(coolint):
+        if coolint == 1.0:
+            return 'off'
+        elif coolint == 2.0:
+            return 'on'  # target temperature = -20 deg
+        else:
+            return 'max'  # target temperature = -31 deg
+
+def fan_status_bool2int(onoff):
+        if onoff:
+            return 2.0
+        else:
+            return 1.0
+
+def fan_status_int2bool(onoffint):
+        if onoffint == 1.0:
+            return False
+        elif onoffint == 2.0:
+            return True
+
 
 def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisition=True):
     def getter(self):
@@ -30,6 +60,10 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
                 return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)) * 1e6
             elif hamamatsu_property_name in ['SUBARRAYHSIZE', 'SUBARRAYVSIZE', 'SUBARRAYVPOS', 'SUBARRAYHPOS']:
                 return int(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
+            elif hamamatsu_property_name == 'SENSORCOOLER':
+                return cooler_mode_int2string(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
+            elif hamamatsu_property_name == 'SENSORCOOLERFAN':
+                return fan_status_int2bool(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
             else:
                 return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))
 
@@ -48,6 +82,10 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
             with self.mutex:
                 if hamamatsu_property_name == 'EXPOSURETIME':
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value / 1e6)
+                if hamamatsu_property_name == 'SENSORCOOLER':
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), cooler_mode_string2int(value))
+                if hamamatsu_property_name == 'SENSORCOOLERFAN':
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), cooler_mode_int2string(value))
                 else:
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value)
             if was_running and stopped_acquisition:
@@ -199,19 +237,18 @@ class HamamatsuCamera(Service):
         self.temperature = self.make_data_stream('temperature', 'float64', [1], 20)
 
         make_property_helper('exposure_time')
+        make_property_helper('gain', read_only=True)
+        make_property_helper('brightness', read_only=True)
 
         make_property_helper('width')
         make_property_helper('height')
         make_property_helper('offset_x')
         make_property_helper('offset_y')
-
-        make_property_helper('gain', read_only=True)
-        make_property_helper('brightness', read_only=True)
-        make_property_helper('fan_status')
-        make_property_helper('cooler_mode')
-
         make_property_helper('sensor_width', read_only=True)
         make_property_helper('sensor_height', read_only=True)
+
+        make_property_helper('fan_status')
+        make_property_helper('cooler_mode')
 
         self.make_command('start_acquisition', self.start_acquisition)
         self.make_command('end_acquisition', self.end_acquisition)
@@ -312,82 +349,6 @@ class HamamatsuCamera(Service):
 
             self.sleep(0.1)
 
-    @property
-    def cooler_mode(self):
-        """
-        Check the cooling mode.
-
-        Returns
-        -------
-        str :
-            Sensor cooler status 'on', 'off' or 'max'.
-        """
-        coolint = self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSORCOOLER)
-
-        if coolint == 1.0:
-            return 'off'
-        elif coolint == 2.0:
-            return 'on'  # target temperature = -20 deg
-        else:
-            return 'max'  # target temperature = -31 deg
-
-    @cooler_mode.setter
-    def cooler_mode(self, coolstr):
-        """
-        Set the cooling mode.
-
-        Parameters
-        ----------
-        coolstr : str
-            Cooling mode of the camera.
-        """
-
-        if coolstr == 'off':
-            coolint = 1.0
-        elif coolstr == 'on':
-            coolint = 2.0
-        elif coolstr == 'max':
-            coolint = 4.0
-        else:
-            raise ValueError('Water cooling mode not recognized.')
-
-        self.cam.prop_setvalue(dcam.DCAM_IDPROP.SENSORCOOLER, coolint)
-
-    @property
-    def fan_status(self):
-        """
-        Check fan status
-
-        Returns
-        -------
-        bool :
-            Fan status True or False.
-        """
-        onoffint = self.cam.prop_getvalue(dcam.DCAM_IDPROP.SENSORCOOLERFAN)
-
-        if onoffint == 1.0:
-            return False
-        elif onoffint == 2.0:
-            return True
-
-    @fan_status.setter
-    def fan_status(self, onoff=True):
-        """
-        Start / stop the the camera fan.
-
-        Parameters
-        ----------
-        onoff : bool
-            True or False to start or stop the fan.
-        """
-
-        if onoff:
-            onoffint = 2.0
-        else:
-            onoffint = 1.0
-
-        self.cam.prop_setvalue(dcam.DCAM_IDPROP.SENSORCOOLERFAN, onoffint)
-
     def start_acquisition(self):
         """
         Start the acquisition loop.
@@ -405,6 +366,9 @@ class HamamatsuCamera(Service):
         self.should_be_acquiring.clear()
 
     exposure_time = _create_property('EXPOSURETIME', stopped_acquisition=False)
+
+    cooler_mode = _create_property('SENSORCOOLER', stopped_acquisition=False)
+    fan_status = _create_property('SENSORCOOLERFAN', stopped_acquisition=False)
 
     width = _create_property('SUBARRAYHSIZE')
     height = _create_property('SUBARRAYVSIZE')

--- a/docs/services/hamamatsu_camera.rst
+++ b/docs/services/hamamatsu_camera.rst
@@ -64,8 +64,6 @@ Commands
 
 ``end_acquisition()``: This ends the acquisition of images from the camera.
 
-``get_temperature()``: Get the camera temperature.
-
 Datastreams
 -----------
 ``temperature``: The temperature (in Celsius) as measured by the camera.

--- a/docs/services/hamamatsu_camera.rst
+++ b/docs/services/hamamatsu_camera.rst
@@ -64,6 +64,8 @@ Commands
 
 ``end_acquisition()``: This ends the acquisition of images from the camera.
 
+``get_temperature()``: Get the camera temperature.
+
 Datastreams
 -----------
 ``temperature``: The temperature (in Celsius) as measured by the camera.

--- a/docs/services/hamamatsu_camera.rst
+++ b/docs/services/hamamatsu_camera.rst
@@ -29,14 +29,13 @@ Configuration
       camera_mode: 'ultraquiet'
       pixel_format: Mono16
       binning: 1
+      critical_temperature: 28
 
       offset_x: 0
       offset_y: 0
       width: 400
       height: 400
-      exposure_time: 8294.4
-
-      critical_temperature=28
+      exposure_time: 8317.5
 
 Properties
 ----------
@@ -54,7 +53,7 @@ Properties
 
 ``sensor_height``: The height of the sensor.
 
-``cooler mode``: Cooler mode (only in water cooling): 'off', 'on' or 'max' .
+``cooler_mode``: Cooler mode (only in water cooling): 'off', 'on' or 'max' .
 
 ``fan_status``: Current camera fan status: 'off', 'on'.
 

--- a/docs/services/hamamatsu_camera.rst
+++ b/docs/services/hamamatsu_camera.rst
@@ -36,6 +36,8 @@ Configuration
       height: 400
       exposure_time: 8294.4
 
+      critical_temperature=28
+
 Properties
 ----------
 ``exposure_time``: Exposure time of the camera in microseconds.
@@ -52,11 +54,17 @@ Properties
 
 ``sensor_height``: The height of the sensor.
 
+``cooler mode``: Cooler mode (only in water cooling).
+
+``fan_status``: Current camera fan status.
+
 Commands
 --------
 ``start_acquisition()``: This starts the acquisition of images from the camera.
 
 ``end_acquisition()``: This ends the acquisition of images from the camera.
+
+``get_temperature()``: Get the camera temperature.
 
 Datastreams
 -----------

--- a/docs/services/hamamatsu_camera.rst
+++ b/docs/services/hamamatsu_camera.rst
@@ -25,7 +25,7 @@ Configuration
 
       camera_id: 0
       cooling_mode: 'on'
-      fan_on: false
+      fan_status: 'off'
       camera_mode: 'ultraquiet'
       pixel_format: Mono16
       binning: 1
@@ -54,9 +54,9 @@ Properties
 
 ``sensor_height``: The height of the sensor.
 
-``cooler mode``: Cooler mode (only in water cooling).
+``cooler mode``: Cooler mode (only in water cooling): 'off', 'on' or 'max' .
 
-``fan_status``: Current camera fan status.
+``fan_status``: Current camera fan status: 'off', 'on'.
 
 Commands
 --------


### PR DESCRIPTION
Added setter and getter for 
- fan status (on/off)
- Cooler mode (off/on/max)

Added safety based on temperature. 
If temperature > 28 degrees (can be changed in yaml parameter), fan start and acquisition stops.
Fix issue: https://github.com/ivalaginja/thd-controls/issues/419 

The following properties (documented in the support parameter manual and/or directly in the dcamapi4.py python file) do not seem to work, at least not for orca quest 2 (C15550-22UP): 
- SENSORCOOLERSTATUS supposed to return "busy" when camera is still cooling to target
- SENSORTEMPERATURE_STATUS supposed to return a warning in case of error in the temperature ? (not documented in the manual, only appear in dcamapi4.py)





