### PR TITLE
Use Enums for cooler and fan settings

### DIFF
--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -63,9 +63,9 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
                 if hamamatsu_property_name == 'EXPOSURETIME':
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value / 1e6)
                 elif hamamatsu_property_name == 'SENSORCOOLER':
-                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), CoolerMode(value).value)
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), CoolerMode[value].value)
                 elif hamamatsu_property_name == 'SENSORCOOLERFAN':
-                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), FanStatus(value).value)
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), FanStatus[value].value)
                 else:
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value)
 

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -40,17 +40,21 @@ class CoolerMode(Enum):
         return self.name.lower()
 
 
-def fan_status_bool2int(onoff):
-        if onoff:
-            return 2.0
-        else:
-            return 1.0
+class FanStatus(Enum):
+    OFF = 1.0
+    ON = 2.0
 
-def fan_status_int2bool(onoffint):
-        if onoffint == 1.0:
-            return False
-        elif onoffint == 2.0:
-            return True
+    @classmethod
+    def from_bool(cls, val):
+        return cls.ON if val else cls.OFF
+
+    @classmethod
+    def from_int(cls, val):
+        return cls(val)
+
+    def to_bool(self):
+        return self is FanStatus.ON
+
 
 def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisition=True):
     def getter(self):
@@ -62,7 +66,7 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
             elif hamamatsu_property_name == 'SENSORCOOLER':
                 return str(CoolerMode(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))))
             elif hamamatsu_property_name == 'SENSORCOOLERFAN':
-                return fan_status_int2bool(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
+                return FanStatus.from_int(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)).to_bool())
             else:
                 return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))
 
@@ -84,9 +88,10 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
                 elif hamamatsu_property_name == 'SENSORCOOLER':
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), CoolerMode.from_string(value).value)
                 elif hamamatsu_property_name == 'SENSORCOOLERFAN':
-                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), fan_status_bool2int(value))
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), FanStatus.from_bool(value).value)
                 else:
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value)
+
             if was_running and stopped_acquisition:
                 self.start_acquisition()
 

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -25,36 +25,13 @@ except ImportError:
 
 
 class CoolerMode(Enum):
-    OFF = 1.0
-    ON = 2.0    # target temperature = -20 deg
-    MAX = 4.0   # target temperature = -31 deg
-
-    @classmethod
-    def from_string(cls, coolstr):
-        try:
-            return cls[coolstr.upper()]
-        except KeyError:
-            raise ValueError('Water cooling mode not recognized.')
-
-    def __str__(self):
-        return self.name.lower()
-
+    off = 1.0
+    on = 2.0    # target temperature = -20 deg
+    max = 4.0   # target temperature = -31 deg
 
 class FanStatus(Enum):
-    OFF = 1.0
-    ON = 2.0
-
-    @classmethod
-    def from_bool(cls, val):
-        return cls.ON if val else cls.OFF
-
-    @classmethod
-    def from_int(cls, val):
-        return cls(val)
-
-    def to_bool(self):
-        return self is FanStatus.ON
-
+    off = 1.0
+    on = 2.0
 
 def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisition=True):
     def getter(self):
@@ -64,9 +41,9 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
             elif hamamatsu_property_name in ['SUBARRAYHSIZE', 'SUBARRAYVSIZE', 'SUBARRAYVPOS', 'SUBARRAYHPOS']:
                 return int(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
             elif hamamatsu_property_name == 'SENSORCOOLER':
-                return str(CoolerMode(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))))
+                return CoolerMode(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))).name
             elif hamamatsu_property_name == 'SENSORCOOLERFAN':
-                return FanStatus.from_int(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)).to_bool())
+                return FanStatus(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))).name
             else:
                 return self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))
 
@@ -86,9 +63,9 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
                 if hamamatsu_property_name == 'EXPOSURETIME':
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value / 1e6)
                 elif hamamatsu_property_name == 'SENSORCOOLER':
-                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), CoolerMode.from_string(value).value)
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), CoolerMode(value).value)
                 elif hamamatsu_property_name == 'SENSORCOOLERFAN':
-                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), FanStatus.from_bool(value).value)
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), FanStatus(value).value)
                 else:
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value)
 
@@ -264,7 +241,7 @@ class HamamatsuCamera(Service):
         self.cooler_mode = self.config.get('cooling_mode', 'on')
 
         # check fan status and start / stop fan
-        self.fan_status = self.config.get('fan_on', True)
+        self.fan_status = self.config.get('fan_status', 'off')
 
         self.temperature_thread = threading.Thread(target=self.monitor_temperature)
         self.temperature_thread.start()
@@ -348,7 +325,7 @@ class HamamatsuCamera(Service):
             if temperature > self.critical_temperature and self.is_acquiring.get():
                 self.log.warning(f'Camera temperature = {temperature} > {self.critical_temperature} degrees.')
                 self.log.warning('Stopping acquisition and start fan.')
-                self.fan_status = True
+                self.fan_status = 'on'
                 self.cooler_mode = 'on'
                 self.end_acquisition()
 

--- a/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
+++ b/catkit2/services/hamamatsu_camera/hamamatsu_camera.py
@@ -4,6 +4,7 @@ This module contains a service for Hamamatsu digital cameras.
 This service is a wrapper around the DCAM-SDK4.
 It provides a simple interface to control the camera and acquire images.
 """
+from enum import Enum
 import os
 import sys
 import threading
@@ -22,23 +23,22 @@ except ImportError:
     print('To use Hamamatsu cameras, you need to set the CATKIT_DCAM_SDK_PATH environment variable.')
     raise
 
-def cooler_mode_string2int(coolstr):
-        if coolstr == 'off':
-            return 1.0
-        elif coolstr == 'on':
-            return 2.0  # target temperature = -20 deg
-        elif coolstr == 'max':
-            return 4.0  # target temperature = -31 deg
-        else:
-            raise ValueError('Not recognized in water cooling mode.')
 
-def cooler_mode_int2string(coolint):
-        if coolint == 1.0:
-            return 'off'
-        elif coolint == 2.0:
-            return 'on'  # target temperature = -20 deg
-        else:
-            return 'max'  # target temperature = -31 deg
+class CoolerMode(Enum):
+    OFF = 1.0
+    ON = 2.0    # target temperature = -20 deg
+    MAX = 4.0   # target temperature = -31 deg
+
+    @classmethod
+    def from_string(cls, coolstr):
+        try:
+            return cls[coolstr.upper()]
+        except KeyError:
+            raise ValueError('Water cooling mode not recognized.')
+
+    def __str__(self):
+        return self.name.lower()
+
 
 def fan_status_bool2int(onoff):
         if onoff:
@@ -60,7 +60,7 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
             elif hamamatsu_property_name in ['SUBARRAYHSIZE', 'SUBARRAYVSIZE', 'SUBARRAYVPOS', 'SUBARRAYHPOS']:
                 return int(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
             elif hamamatsu_property_name == 'SENSORCOOLER':
-                return cooler_mode_int2string(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
+                return str(CoolerMode(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name))))
             elif hamamatsu_property_name == 'SENSORCOOLERFAN':
                 return fan_status_int2bool(self.cam.prop_getvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name)))
             else:
@@ -82,7 +82,7 @@ def _create_property(hamamatsu_property_name, read_only=False, stopped_acquisiti
                 if hamamatsu_property_name == 'EXPOSURETIME':
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), value / 1e6)
                 elif hamamatsu_property_name == 'SENSORCOOLER':
-                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), cooler_mode_string2int(value))
+                    self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), CoolerMode.from_string(value).value)
                 elif hamamatsu_property_name == 'SENSORCOOLERFAN':
                     self.cam.prop_setvalue(getattr(dcam.DCAM_IDPROP, hamamatsu_property_name), fan_status_bool2int(value))
                 else:

--- a/docs/services/hamamatsu_camera.rst
+++ b/docs/services/hamamatsu_camera.rst
@@ -25,7 +25,7 @@ Configuration
 
       camera_id: 0
       cooling_mode: 'on'
-      fan_on: false
+      fan_status: 'off'
       camera_mode: 'ultraquiet'
       pixel_format: Mono16
       binning: 1
@@ -54,9 +54,9 @@ Properties
 
 ``sensor_height``: The height of the sensor.
 
-``cooler mode``: Cooler mode (only in water cooling).
+``cooler mode``: Cooler mode (only in water cooling): 'off', 'on' or 'max' .
 
-``fan_status``: Current camera fan status.
+``fan_status``: Current camera fan status: 'off', 'on'.
 
 Commands
 --------


### PR DESCRIPTION
Suggested change for #364, which is otherwise ready. Enums are a much safer way to map values, and it also removes the requirement to come up with random function names.

If you could give this a spin on hardware @johanmazoyer then we could merge the two PRs sequentially.