### PR TITLE
Adapt simulated service of optical switch

### DIFF
--- a/catkit2/services/optical_fiber_switch_sim/optical_fiber_switch_sim.py
+++ b/catkit2/services/optical_fiber_switch_sim/optical_fiber_switch_sim.py
@@ -41,9 +41,7 @@ class OpticalFiberSwitchSim(Service):
         self.get_input_channel()
 
     def get_input_channel(self):
-        # Read the response
-        # TODO: Set testbed simulator to handle this command
-        current_channel = 1
+        current_channel = self.input_channel.get()[0]  # Yes, total hack
         self.current_input.submit_data(np.array([current_channel], dtype='int8'))
 
     def close(self):

--- a/catkit2/services/optical_fiber_switch_sim/optical_fiber_switch_sim.py
+++ b/catkit2/services/optical_fiber_switch_sim/optical_fiber_switch_sim.py
@@ -35,9 +35,7 @@ class OpticalFiberSwitchSim(Service):
         if channel < self.min_channel or channel > self.max_channel:
             raise ValueError(f"Channel must be between {self.min_channel} and {self.max_channel}.")
 
-        # Send the command to the switch
-        # TODO: Set testbed simulator to handle this command
-        # self.testbed.simulator.set_source_power()  # Or something like that
+        self.testbed.simulator.set_source_power(source_name=self.id, power=channel)
         self.log.info(f"Switch to input channel {channel}.")
         self.sleep(0.1)
         self.get_input_channel()

--- a/catkit2/services/optical_fiber_switch_sim/optical_fiber_switch_sim.py
+++ b/catkit2/services/optical_fiber_switch_sim/optical_fiber_switch_sim.py
@@ -33,7 +33,7 @@ class OpticalFiberSwitchSim(Service):
     def set_input_channel(self, channel):
         # Construct the command to set the input channel
         if channel < self.min_channel or channel > self.max_channel:
-            raise ValueError(f"Channel must be between {self.min_ochannel} and {self.max_channel}.")
+            raise ValueError(f"Channel must be between {self.min_channel} and {self.max_channel}.")
 
         # Send the command to the switch
         # TODO: Set testbed simulator to handle this command


### PR DESCRIPTION
Depends on https://github.com/spacetelescope/catkit2/pull/374.

Makes the simulated service work with a testbed simulator.
