### PR TITLE
Add default input channel for simulated optical switch

### DIFF
--- a/catkit2/services/optical_fiber_switch_sim/optical_fiber_switch_sim.py
+++ b/catkit2/services/optical_fiber_switch_sim/optical_fiber_switch_sim.py
@@ -17,6 +17,9 @@ class OpticalFiberSwitchSim(Service):
     def open(self):
         self.input_channel = self.make_data_stream('input_channel', 'int8', [1], 20)
         self.current_input = self.make_data_stream('current_input', 'int8', [1], 20)
+        # In sim, we start off from the same input channel each time
+        self.input_channel.submit_data(np.array([1], dtype='int8'))
+
         self.get_input_channel()
 
     def main(self):

--- a/catkit2/testbed/proxies/optical_fiber_switch.py
+++ b/catkit2/testbed/proxies/optical_fiber_switch.py
@@ -28,5 +28,5 @@ class OpticalFiberSwitchProxy(ServiceProxy):
         return self.config['channels']
 
     def get_named_channel(self, channel):
-        named_channel = [str(i) for i in self.channels if self.channels[i] == channel]
+        named_channel = [str(i) for i in self.channels if self.channels[i] == channel][0]
         return named_channel


### PR DESCRIPTION
The data stream that is supposed to provide the input channel is empty upon creation of the simulated service for the optical switch. I made it contain 1 as a default when the service opens.

Code sneak: returned named channel from the proxy should not be a list.