### PR TITLE
Update protobuf binary directory path in CMakeLists.txt to avoid a compilation issue on Rocky Linux 9

### DIFF
--- a/catkit_core/CMakeLists.txt
+++ b/catkit_core/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(Protobuf REQUIRED)
 target_include_directories(catkit_core PUBLIC ${PROTOBUF_INCLUDE_DIR})
 target_link_libraries(catkit_core PUBLIC ${PROTOBUF_LIBRARY})
 
-set(PROTO_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/gen/")
+set(PROTO_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/proto/")
 file(MAKE_DIRECTORY "${PROTO_BINARY_DIR}")
 protobuf_generate(
   TARGET catkit_core


### PR DESCRIPTION
Hi,

I tried to install catkit2 on Rocky Linux 9 and encountered the following compilation issue:

```log
      FAILED: [code=1] catkit_core/CMakeFiles/catkit_core.dir/__/proto/core.pb.cc.o
      /usr/bin/g++  -pthread -B /home/micado/miniforge3/envs/catkit2/compiler_compat -DPROTOBUF_USE_DLLS -I/tmp/tmpt925y22a/build/catkit_core -isystem /home/micado/miniforge3/envs/catkit2/include -isystem /home/micado/miniforge3/envs/catkit2/include/eigen3 -O3 -DNDEBUG -fPIC -g -std=gnu++17 -MD -MT catkit_core/CMakeFiles/catkit_core.dir/__/proto/core.pb.cc.o -MF catkit_core/CMakeFiles/catkit_core.dir/__/proto/core.pb.cc.o.d -o catkit_core/CMakeFiles/catkit_core.dir/__/proto/core.pb.cc.o -c /tmp/tmpt925y22a/build/proto/core.pb.cc
      cc1plus: fatal error: /tmp/tmpt925y22a/build/proto/core.pb.cc: No such file or directory
      compilation terminated.
```

With the proposed fix, it works now, but I don’t understand how it could compile before.

I hope it doesn’t break things on Windows or other distributions. I hope GitHub Actions will catch any issues.

Cheers,
Arnaud