### PR TITLE
Move execution of commands and the service proxy obtaining the API to a message broker.

### DIFF
--- a/catkit_core/Service.cpp
+++ b/catkit_core/Service.cpp
@@ -53,8 +53,7 @@ Service::Service(string service_type, string service_id, int service_port, int t
 
 	LOG_DEBUG("Registering request handlers.");
 
-	m_Server.RegisterRequestHandler("get_info", [this](const string &data) { return this->HandleGetInfo(data); });
-	m_Server.RegisterRequestHandler("execute_command", [this](const string &data) { return this->HandleExecuteCommand(data); });
+	m_Server.RegisterRequestHandler("get_info", [this](const string &data) { return this->HandleGetInfo(data); }); });
 	m_Server.RegisterRequestHandler("shut_down", [this](const string &data) { return this->HandleShutDown(data); });
 
 	LOG_INFO("Intialized service.");
@@ -156,13 +155,13 @@ void Service::Run(void (*error_check)())
 		// Start the safety and heartbeat threads.
 		std::thread safety(&Service::MonitorSafety, this);
 		std::thread heartbeat(&Service::MonitorHeartbeats, this);
-		std::thread properties(&Service::MonitorProperties, this);
+		std::thread properties_and_commands(&Service::MonitorPropertiesAndCommands, this);
 
 		// Start the server.
 		m_Server.Start();
 
 		// Ensure the server and started threads are stopped when out of this scope.
-		Finally stop_server_and_monitors([this, &safety, &heartbeat, &properties]()
+		Finally stop_server_and_monitors([this, &safety, &heartbeat, &properties_and_commands]()
 		{
 			this->m_ShouldShutDown = true;
 
@@ -174,8 +173,8 @@ void Service::Run(void (*error_check)())
 			if (heartbeat.joinable())
 				heartbeat.join();
 
-			if (properties.joinable())
-				properties.join();
+			if (properties_and_commands.joinable())
+				properties_and_commands.join();
 		});
 
 		// Update service state.
@@ -354,7 +353,7 @@ void Service::MonitorHeartbeats()
 	}
 }
 
-void Service::MonitorProperties()
+void Service::MonitorPropertiesAndCommands()
 {
 	auto broker = m_Testbed->GetMessageBroker();
 	auto subscription = broker->Subscribe(m_ServiceId);
@@ -371,48 +370,17 @@ void Service::MonitorProperties()
 			auto message = message_optional.value();
 			auto topic = message.GetTopic();
 
-			// Only trigger on set messages.
-			if (topic.substr(topic.size() - 4) != "/set")
-				continue;
-
-			std::string get_topic = std::string(topic.substr(0, topic.size() - 4)) + "/get"s;
-			std::string error_topic = std::string(topic.substr(0, topic.size() - 4)) + "/error"s;
-
-			// Find the property name. The topic is "<service_id>/<property_name>/set".
-			std::string property_name = std::string(topic.substr(m_ServiceId.size() + 1, topic.size()- m_ServiceId.size() - 5));
-
-			// Find the property. If a property by that name doesn't exist, ignore the message.
-			auto property = m_Properties.find(property_name);
-			if (property == m_Properties.end())
-				continue;
-
-			try
+			// Trigger on set messages.
+			if (topic.size() >= 4 && topic.substr(topic.size() - 4) == "/set")
 			{
-				// Set the property value.
-				SetProperty(property_name, std::string_view((char *)message.GetPayload().data, message.GetPayloadSize()));
-			}
-			catch (const std::exception& e)
-			{
-				std::string error_message = "Failed to set property: "s + e.what();
-				LOG_ERROR(error_message);
-
-				broker->PublishData(error_topic, error_message.data(), error_message.size(), message.GetTraceId());
+				HandleSetPropertyMessage(broker, message);
 				continue;
 			}
 
-			try
+			// Trigger on execute messages.
+			if (topic.size() >= 8 && topic.substr(topic.size() - 8) == "/execute")
 			{
-				// Publish the new property value;
-				auto new_property_value = GetProperty(property_name);
-
-				broker->PublishData(get_topic, new_property_value.data(), new_property_value.size(), message.GetTraceId());
-			}
-			catch (const std::exception& e)
-			{
-				std::string error_message = "Failed to get property: "s + e.what();
-				LOG_ERROR(error_message);
-
-				broker->PublishData(error_topic, error_message.data(), error_message.size(), message.GetTraceId());
+				HandleExecuteCommandMessage(broker, message);
 				continue;
 			}
 		}
@@ -420,6 +388,99 @@ void Service::MonitorProperties()
 		{
 			continue;
 		}
+	}
+}
+
+void Service::HandleSetPropertyMessage(std::shared_ptr<MessageBroker> broker, const Message &message)
+{
+	auto topic = message.GetTopic();
+
+	std::string get_topic = std::string(topic.substr(0, topic.size() - 4)) + "/get"s;
+	std::string error_topic = std::string(topic.substr(0, topic.size() - 4)) + "/error"s;
+
+	// Find the property name. The topic is "<service_id>/<property_name>/set".
+	std::string property_name = std::string(topic.substr(m_ServiceId.size() + 1, topic.size() - m_ServiceId.size() - 5));
+
+	// Find the property. If a property by that name doesn't exist, ignore the message.
+	auto property = m_Properties.find(property_name);
+	if (property == m_Properties.end())
+		return;
+
+	try
+	{
+		// Set the property value.
+		SetProperty(property_name, std::string_view((char *)message.GetPayload().data, message.GetPayloadSize()));
+	}
+	catch (const std::exception& e)
+	{
+		std::string error_message = "Failed to set property: "s + e.what();
+		LOG_ERROR(error_message);
+
+		broker->PublishData(error_topic, error_message.data(), error_message.size(), message.GetTraceId());
+		return;
+	}
+
+	try
+	{
+		// Publish the new property value;
+		auto new_property_value = GetProperty(property_name);
+
+		broker->PublishData(get_topic, new_property_value.data(), new_property_value.size(), message.GetTraceId());
+	}
+	catch (const std::exception& e)
+	{
+		std::string error_message = "Failed to get property: "s + e.what();
+		LOG_ERROR(error_message);
+
+		broker->PublishData(error_topic, error_message.data(), error_message.size(), message.GetTraceId());
+		return;
+	}
+}
+
+void Service::HandleExecuteCommandMessage(std::shared_ptr<MessageBroker> broker, const Message &message)
+{
+	auto topic = message.GetTopic();
+
+	std::string return_topic = std::string(topic.substr(0, topic.size() - 8)) + "/return"s;
+	std::string error_topic = std::string(topic.substr(0, topic.size() - 8)) + "/error"s;
+
+	// Find the command name. The topic is "<service_id>/command_name/execute".
+	std::string command_name = std::string(topic.substr(m_ServiceId.size() + 1, topic.size() - m_ServiceId.size() - 9));
+
+	// Find the command. If a command by that name doesn't exist, ignore the message.
+	auto command = m_Commands.find(command_name);
+	if (command == m_Commands.end())
+		return;
+
+	try
+	{
+		// Decode the arguments.
+		catkit_proto::Dict args_proto;
+		args_proto.ParseFromArray(message.GetPayload().data, message.GetPayloadSize());
+
+		Dict args;
+		FromProto(&args_proto, args);
+
+		// Execute the command.
+		auto res = command->second->Execute(args);
+
+		// Encode the return value.
+		catkit_proto::service::ExecuteCommandReply reply;
+		ToProto(res, reply.mutable_result());
+
+		string reply_string;
+		reply.SerializeToString(&reply_string);
+
+		// Publish the return value.
+		broker->PublishData(return_topic, reply_string.data(), reply_string.size(), message.GetTraceId());
+	}
+	catch (const std::exception &e)
+	{
+		// Publish the error on the error topic.
+		std::string error_message = "Failed to execute command: "s + e.what();
+		LOG_ERROR(error_message);
+
+		broker->PublishData(error_topic, error_message.data(), error_message.size(), message.GetTraceId());
 	}
 }
 
@@ -599,30 +660,6 @@ string Service::HandleGetInfo(const string &data)
 	reply.set_heartbeat_stream_id(m_Heartbeat->GetStreamId());
 
 	std::string reply_string;
-	reply.SerializeToString(&reply_string);
-
-	return reply_string;
-}
-
-string Service::HandleExecuteCommand(const string &data)
-{
-	catkit_proto::service::ExecuteCommandRequest request;
-	request.ParseFromString(data);
-
-	std::string command_name = request.command_name();
-	auto command = GetCommand(command_name);
-
-	if (!command)
-		throw std::runtime_error("Command \""s + command_name + "\" does not exist.");
-
-	Dict args;
-	FromProto(&request.arguments(), args);
-	auto res = command->Execute(args);
-
-	catkit_proto::service::ExecuteCommandReply reply;
-	ToProto(res, reply.mutable_result());
-
-	string reply_string;
 	reply.SerializeToString(&reply_string);
 
 	return reply_string;

--- a/catkit_core/Service.cpp
+++ b/catkit_core/Service.cpp
@@ -53,7 +53,6 @@ Service::Service(string service_type, string service_id, int service_port, int t
 
 	LOG_DEBUG("Registering request handlers.");
 
-	m_Server.RegisterRequestHandler("get_info", [this](const string &data) { return this->HandleGetInfo(data); }); });
 	m_Server.RegisterRequestHandler("shut_down", [this](const string &data) { return this->HandleShutDown(data); });
 
 	LOG_INFO("Intialized service.");
@@ -118,6 +117,12 @@ void Service::Run(void (*error_check)())
 	}
 
 	LOG_INFO("Service was succesfully opened.");
+
+	// Publish info.
+	std::string service_info = GetInfo();
+	m_Testbed->GetMessageBroker()->PublishData(m_ServiceId + "/info/get"s, service_info.data(), service_info.size());
+
+	LOG_INFO("Published service info.");
 
 	// Publish all properties on startup.
 	for (const auto &pair : m_Properties)
@@ -638,31 +643,28 @@ void Service::SetProperty(std::string property_name, std::string_view value)
 	setter(val);
 }
 
-string Service::HandleGetInfo(const string &data)
+string Service::GetInfo()
 {
-	// There's no data in the request, so don't even parse it.
-	// Create the reply protobuffer object.
-	catkit_proto::service::GetInfoReply reply;
-
-	reply.set_service_id(m_ServiceId);
-	reply.set_service_type(m_ServiceType);
-	reply.set_config(m_Config.dump());
+	nlohmann::json reply = {
+		{"service_id", m_ServiceId},
+		{"service_type", m_ServiceType},
+		{"config", m_Config},
+		{"property_names", json::array()},
+		{"command_names", json::array()},
+		{"datastream_ids", json::object()},
+		{"heartbeat_stream_id", m_Heartbeat->GetStreamId()}
+	};
 
 	for (auto& [key, value] : m_Properties)
-		reply.add_property_names(key);
+		reply["property_names"].push_back(key);
 
 	for (auto& [key, value] : m_Commands)
-		reply.add_command_names(key);
+		reply["command_names"].push_back(key);
 
 	for (auto& [key, value] : m_DataStreams)
-		(*reply.mutable_datastream_ids())[key] = value->GetStreamId();
+		reply["datastream_ids"][key] = value->GetStreamId();
 
-	reply.set_heartbeat_stream_id(m_Heartbeat->GetStreamId());
-
-	std::string reply_string;
-	reply.SerializeToString(&reply_string);
-
-	return reply_string;
+	return reply.dump();
 }
 
 string Service::HandleShutDown(const string &data)

--- a/catkit_core/Service.cpp
+++ b/catkit_core/Service.cpp
@@ -470,8 +470,8 @@ void Service::HandleExecuteCommandMessage(std::shared_ptr<MessageBroker> broker,
 		auto res = command->second->Execute(args);
 
 		// Encode the return value.
-		catkit_proto::service::ExecuteCommandReply reply;
-		ToProto(res, reply.mutable_result());
+		catkit_proto::Value reply;
+		ToProto(res, &reply);
 
 		string reply_string;
 		reply.SerializeToString(&reply_string);

--- a/catkit_core/Service.h
+++ b/catkit_core/Service.h
@@ -65,10 +65,11 @@ public:
 	void CleanupAttributes();
 
 private:
+	std::string GetInfo();
+
 	std::string GetProperty(std::string property_name);
 	void SetProperty(std::string property_name, std::string_view value);
 
-	std::string HandleGetInfo(const std::string &data);
 	std::string HandleShutDown(const std::string &data);
 
 	void MonitorSafety();

--- a/catkit_core/Service.h
+++ b/catkit_core/Service.h
@@ -21,6 +21,7 @@
 #include "ServiceState.h"
 #include "ProcessStats.h"
 #include "Types.h"
+#include "MessageBroker.h"
 
 const double SERVICE_LIVELINESS = 5;
 
@@ -68,9 +69,6 @@ private:
 	void SetProperty(std::string property_name, std::string_view value);
 
 	std::string HandleGetInfo(const std::string &data);
-
-	std::string HandleExecuteCommand(const std::string &data);
-
 	std::string HandleShutDown(const std::string &data);
 
 	void MonitorSafety();
@@ -78,7 +76,10 @@ private:
 	bool RequiresSafety();
 
 	void MonitorHeartbeats();
-	void MonitorProperties();
+	void MonitorPropertiesAndCommands();
+
+	void HandleSetPropertyMessage(std::shared_ptr<MessageBroker> broker, const Message &message);
+	void HandleExecuteCommandMessage(std::shared_ptr<MessageBroker> broker, const Message &message);
 
 	void UpdateState(ServiceState state);
 

--- a/catkit_core/ServiceProxy.cpp
+++ b/catkit_core/ServiceProxy.cpp
@@ -187,11 +187,11 @@ Value ServiceProxy::ExecuteCommand(const std::string &name, const Dict &argument
 			throw std::runtime_error("Error while executing command: "s + std::string((char *) reply_message.GetPayload().data, reply_message.GetPayloadSize()));
 
 		// Parse the response message and return the retrieved value.
-		catkit_proto::service::ExecuteCommandReply reply;
+		catkit_proto::Value reply;
 		reply.ParseFromString(std::string((char *) reply_message.GetPayload().data, reply_message.GetPayloadSize()));
 
 		Value res;
-		FromProto(&reply.result(), res);
+		FromProto(&reply, res);
 
 		return res;
 	}

--- a/catkit_core/ServiceProxy.cpp
+++ b/catkit_core/ServiceProxy.cpp
@@ -14,6 +14,7 @@ using namespace std::string_literals;
 
 const double TIMEOUT_TO_START = 120;  // seconds
 const double TIMEOUT_SET_PROPERTY = 120;  // seconds
+const double TIMEOUT_EXECUTE_COMMAND = 120;  // seconds
 
 ServiceProxy::ServiceProxy(std::shared_ptr<TestbedProxy> testbed, std::string service_id)
 	: m_Testbed(testbed), m_ServiceId(service_id), m_Client(nullptr), m_State(nullptr),
@@ -140,19 +141,59 @@ Value ServiceProxy::ExecuteCommand(const std::string &name, const Dict &argument
 	if (std::find(m_CommandNames.begin(), m_CommandNames.end(), name) == m_CommandNames.end())
 		throw std::runtime_error("This is not a valid command name.");
 
-	catkit_proto::service::ExecuteCommandRequest request;
-	request.set_command_name(name);
-	ToProto(arguments, request.mutable_arguments());
+	std::string execute_topic = m_ServiceId + "/"s + name + "/execute"s;
+	std::string error_topic = m_ServiceId + "/"s + name + "/error";
 
-	std::string reply_string = m_Client->MakeRequest("execute_command", Serialize(request));
+	catkit_proto::Dict args;
+	ToProto(arguments, &args);
 
-	catkit_proto::service::ExecuteCommandReply reply;
-	reply.ParseFromString(reply_string);
+	// Subscribe to reply messages.
+	auto subscription = m_Testbed->GetMessageBroker()->Subscribe(m_ServiceId + "/"s + name, MessageSubscriptionMode::Sequential);
 
-	Value res;
-	FromProto(&reply.result(), res);
+	// Send the execute message.
+	auto message_data = Serialize(args);
+	auto message = m_Testbed->GetMessageBroker()->PublishData(execute_topic, message_data.data(), message_data.size());
+	Uuid trace_id = message.GetTraceId();
 
-	return res;
+	// Wait for the response.
+	Timer timer;
+
+	while (true)
+	{
+		double time_remaining = TIMEOUT_EXECUTE_COMMAND - timer.GetTime();
+
+		if (time_remaining < 0)
+			throw std::runtime_error("Timeout waiting for return value.");
+
+		// Get the response message.
+		auto reply_message_optional = subscription.GetNextMessage(time_remaining, EventWaitMethod::Default, error_check);
+
+		if (!reply_message_optional.has_value())
+			continue;
+
+		auto reply_message = reply_message_optional.value();
+
+		// Check if the message is a response to our execute message.
+		if (reply_message.GetTraceId() != trace_id)
+			continue;
+
+		// Ignore the message we just sent.
+		if (reply_message.GetTopic() == execute_topic)
+			continue;
+
+		// If it's an error topic, relay the error to the caller as an exception.
+		if (reply_message.GetTopic() == error_topic)
+			throw std::runtime_error("Error while executing command: "s + std::string((char *) reply_message.GetPayload().data, reply_message.GetPayloadSize()));
+
+		// Parse the response message and return the retrieved value.
+		catkit_proto::service::ExecuteCommandReply reply;
+		reply.ParseFromString(std::string((char *) reply_message.GetPayload().data, reply_message.GetPayloadSize()));
+
+		Value res;
+		FromProto(&reply.result(), res);
+
+		return res;
+	}
 }
 
 std::shared_ptr<DataStream> ServiceProxy::GetDataStream(const std::string &name, void (*error_check)())

--- a/catkit_core/ServiceProxy.cpp
+++ b/catkit_core/ServiceProxy.cpp
@@ -11,6 +11,7 @@
 #include <stdexcept>
 
 using namespace std::string_literals;
+using json = nlohmann::json;
 
 const double TIMEOUT_TO_START = 120;  // seconds
 const double TIMEOUT_SET_PROPERTY = 120;  // seconds
@@ -361,22 +362,24 @@ void ServiceProxy::Connect()
 	// Connect to the service.
 	m_Client = std::make_unique<Client>(service_info.host, service_info.port);
 
-	// Get property, command and datastream names.
-	std::string reply_string = m_Client->MakeRequest("get_info", "");
+	auto info_message = m_Testbed->GetMessageBroker()->GetCurrentMessage(m_ServiceId + "/info"s);
 
-	catkit_proto::service::GetInfoReply reply;
-	reply.ParseFromString(reply_string);
+	if (!info_message.has_value())
+		throw std::runtime_error("The service did not publish its info.");
 
-	for (auto &i : reply.property_names())
-		m_PropertyNames.push_back(i);
+	auto info_payload = info_message.value().GetPayload();
+	auto info = json::parse((char *) info_payload.data, (char *) info_payload.data + info_payload.info.GetSizeInBytes());
 
-	for (auto &i : reply.command_names())
-		m_CommandNames.push_back(i);
+	for (auto it : info["property_names"])
+		m_PropertyNames.push_back(it);
 
-	for (auto& [key, value] : reply.datastream_ids())
+	for (auto it : info["command_names"])
+		m_CommandNames.push_back(it);
+
+	for (auto& [key, value] : info["datastream_ids"].items())
 		m_DataStreamIds[key] = value;
 
-	m_Heartbeat = DataStream::Open(reply.heartbeat_stream_id());
+	m_Heartbeat = DataStream::Open(info["heartbeat_stream_id"].get<std::string>());
 
 	m_TimeLastConnect = frame.m_TimeStamp;
 	LOG_DEBUG("Connected to \"" + m_ServiceId + "\".");

--- a/proto/service.proto
+++ b/proto/service.proto
@@ -4,34 +4,6 @@ import "core.proto";
 
 package catkit_proto.service;
 
-message GetInfoRequest
-{
-}
-
-message GetInfoReply
-{
-    string service_id = 1;
-    string service_type = 2;
-    string config = 3;
-
-    repeated string property_names = 4;
-    repeated string command_names = 5;
-    map<string, string> datastream_ids = 6;
-
-    string heartbeat_stream_id = 7;
-}
-
-message ExecuteCommandRequest
-{
-    string command_name = 1;
-    Dict arguments = 2;
-}
-
-message ExecuteCommandReply
-{
-    Value result = 1;
-}
-
 message ShutDownRequest
 {
 }


### PR DESCRIPTION
The dissemination of the API (names of properties, commands and data streams, the heartbeat stream id, configuration) and executing commands is currently done using the Server/Client C++ classes over TCP using ZeroMQ. This PR changes this to be done via the message broker instead. This is part of an ongoing transition from ZeroMQ to a fully message broker communication. After this PR, only the shutdown request to a service, and service registration at the testbed server is done via ZeroMQ.