### PR TITLE
Add debug print function for message broker.

### DIFF
--- a/catkit2/bindings.cpp
+++ b/catkit2/bindings.cpp
@@ -1190,6 +1190,7 @@ PYBIND11_MODULE(catkit_bindings, m)
 		.def("get_oldest_message_id", &LocalMessageBroker::GetOldestMessageId)
 		.def("get_message_rate", &LocalMessageBroker::GetMessageRate)
 		.def("get_all_message_topics", &LocalMessageBroker::GetAllMessageTopics)
+		.def("print_debug_info", &LocalMessageBroker::PrintDebugInfo)
 		.def("subscribe", [](std::shared_ptr<LocalMessageBroker> broker, std::string topic, py::object preferred_next_frame_id, MessageSubscriptionMode mode)
 		{
 			// Check if the starting frame ID is a number or None.

--- a/catkit_core/BuddyAllocator.cpp
+++ b/catkit_core/BuddyAllocator.cpp
@@ -422,3 +422,31 @@ void BuddyAllocator::PrintState() const
 		}
 	}
 }
+
+size_t BuddyAllocator::GetUsage() const
+{
+	size_t used = 0;
+
+	for (size_t level = 1; level < m_Depth; ++level)
+	{
+		Handle begin = 1 << (level - 1);
+		Handle end = 1 << level;
+
+		size_t size = GetSize(begin);
+
+		for (Handle i = begin; i < end; ++i)
+		{
+			auto val = m_Tree[i].load(std::memory_order_relaxed);
+
+			if (val & OCC)
+				used += size;
+		}
+	}
+
+	return used;
+}
+
+size_t BuddyAllocator::GetCapacity() const
+{
+	return m_Capacity;
+}

--- a/catkit_core/BuddyAllocator.h
+++ b/catkit_core/BuddyAllocator.h
@@ -32,6 +32,9 @@ public:
 
 	void PrintState() const;
 
+	size_t GetUsage() const;
+	size_t GetCapacity() const;
+
 private:
 	BuddyAllocator(std::size_t capacity, std::size_t min_size, std::atomic_uint16_t *tree, std::atomic_size_t *last_success, std::shared_ptr<Memory> memory_block);
 

--- a/catkit_core/HashMap.cpp
+++ b/catkit_core/HashMap.cpp
@@ -296,6 +296,11 @@ std::vector<std::string> HashMap::GetAllKeys() const
 	return res;
 }
 
+size_t HashMap::GetCapacity() const
+{
+	return m_NumEntries;
+}
+
 ShareableType HashMap::GetType() const
 {
 	return ShareableType::HashMap;

--- a/catkit_core/HashMap.h
+++ b/catkit_core/HashMap.h
@@ -53,6 +53,7 @@ public:
 	void *Find(std::string_view key) const;
 
 	std::vector<std::string> GetAllKeys() const;
+	size_t GetCapacity() const;
 
 	ShareableType GetType() const override;
 };

--- a/catkit_core/HybridPoolAllocator.cpp
+++ b/catkit_core/HybridPoolAllocator.cpp
@@ -335,3 +335,13 @@ HybridPoolAllocator::Bucket &HybridPoolAllocator::GetBucket(std::size_t level)
 
 	return m_Buckets[thread_id][level];
 }
+
+size_t HybridPoolAllocator::GetUsage() const
+{
+	return m_Allocator->GetUsage();
+}
+
+size_t HybridPoolAllocator::GetCapacity() const
+{
+	return m_Allocator->GetCapacity();
+}

--- a/catkit_core/HybridPoolAllocator.h
+++ b/catkit_core/HybridPoolAllocator.h
@@ -40,6 +40,9 @@ public:
 
 	std::size_t GetOffset(Handle handle) const;
 
+	size_t GetUsage() const;
+	size_t GetCapacity() const;
+
 public:
 	HybridPoolAllocator(std::size_t capacity, std::size_t min_size, std::size_t min_size_pool, std::shared_ptr<BuddyAllocator> allocator, Pool *pools, std::shared_ptr<Memory> memory_block);
 	~HybridPoolAllocator();

--- a/catkit_core/LocalMessageBroker.cpp
+++ b/catkit_core/LocalMessageBroker.cpp
@@ -685,3 +685,12 @@ TopicHeader *LocalMessageBroker::GetTopicHeader(std::string_view topic)
 
 	return topic_header;
 }
+
+void LocalMessageBroker::PrintDebugInfo() const
+{
+	auto topics = m_TopicHeaders->GetAllKeys();
+
+	std::cout << "LocalMessageBroker " << this << ":" << std::endl
+		<< "  Number of topics: " << topics.size() << " / " << m_TopicHeaders->GetCapacity() << std::endl
+		<< "  Message headers: " << m_MessageHeaderAllocator->GetNumUsedBlocks() << " / " << m_MessageHeaderAllocator->GetCapacity() << std::endl;
+}

--- a/catkit_core/LocalMessageBroker.cpp
+++ b/catkit_core/LocalMessageBroker.cpp
@@ -692,5 +692,15 @@ void LocalMessageBroker::PrintDebugInfo() const
 
 	std::cout << "LocalMessageBroker " << this << ":" << std::endl
 		<< "  Number of topics: " << topics.size() << " / " << m_TopicHeaders->GetCapacity() << std::endl
-		<< "  Message headers: " << m_MessageHeaderAllocator->GetNumUsedBlocks() << " / " << m_MessageHeaderAllocator->GetCapacity() << std::endl;
+		<< "  Message headers: " << m_MessageHeaderAllocator->GetNumUsedBlocks() << " / " << m_MessageHeaderAllocator->GetCapacity() << std::endl
+		<< "  Message payloads:" << std::endl;
+
+	size_t i = 0;
+
+	for (auto &alloc : m_Allocators)
+	{
+		std::cout << "    Block " << i << ": " << alloc->GetUsage() << " / " << alloc->GetCapacity() << std::endl;
+
+		i++;
+	}
 }

--- a/catkit_core/LocalMessageBroker.h
+++ b/catkit_core/LocalMessageBroker.h
@@ -115,6 +115,8 @@ public:
 
 	ShareableType GetType() const override;
 
+	virtual void PrintDebugInfo() const override;
+
 private:
 	Message FetchMessage(TopicHeader *topic_header, size_t frame_id);
 	std::uint64_t GetNextMessageId(TopicHeader *topic_header, size_t preferred_next_frame_id, MessageSubscriptionMode mode);

--- a/catkit_core/MessageBroker.cpp
+++ b/catkit_core/MessageBroker.cpp
@@ -250,3 +250,7 @@ MessageSubscription MessageBroker::Subscribe(std::string_view topic, size_t pref
 {
 	return MessageSubscription(shared_from_this(), topic, preferred_next_frame_id, mode);
 }
+
+void MessageBroker::PrintDebugInfo() const
+{
+}

--- a/catkit_core/MessageBroker.h
+++ b/catkit_core/MessageBroker.h
@@ -175,6 +175,8 @@ public:
 
 	MessageSubscription Subscribe(std::string_view topic, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly);
 	MessageSubscription Subscribe(std::string_view topic, size_t preferred_next_frame_id, MessageSubscriptionMode mode = MessageSubscriptionMode::NewestOnly);
+
+	virtual void PrintDebugInfo() const;
 };
 
 #endif // MESSAGE_BROKER_H

--- a/catkit_core/PoolAllocator.cpp
+++ b/catkit_core/PoolAllocator.cpp
@@ -142,3 +142,21 @@ ShareableType PoolAllocator::GetType() const
 {
 	return ShareableType::PoolAllocator;
 }
+
+size_t PoolAllocator::GetNumUsedBlocks() const
+{
+	size_t count = 0;
+
+	for (size_t i = 0; i < m_Capacity; ++i)
+	{
+		if (m_RefCount[i].load(std::memory_order_relaxed) > 0)
+			count++;
+	}
+
+	return count;
+}
+
+size_t PoolAllocator::GetCapacity() const
+{
+	return m_Capacity;
+}

--- a/catkit_core/PoolAllocator.h
+++ b/catkit_core/PoolAllocator.h
@@ -28,6 +28,9 @@ public:
 
 	ShareableType GetType() const override;
 
+	size_t GetNumUsedBlocks() const;
+	size_t GetCapacity() const;
+
 private:
 	PoolAllocator(std::uint32_t capacity, std::atomic<BlockHandle> *head, std::atomic<BlockHandle> *next, std::atomic_size_t *ref_count, std::shared_ptr<Memory> memory_block);
 


### PR DESCRIPTION
This is for getting more detailed information while running the message broker.

Example debug info:
```
LocalMessageBroker 0x1166e4810:
  Number of topics: 223 / 16384
  Message headers: 1109 / 65536
  Message payloads:
    Block 0: 286720 / 2147483648
```