### PR TITLE
Updating the VCP port (12/25). Adding test for catching behavior. 

### DIFF
--- a/catkit2/services/thorlabs_mcls1/thorlabs_mcls1.py
+++ b/catkit2/services/thorlabs_mcls1/thorlabs_mcls1.py
@@ -76,7 +76,10 @@ def make_getter(command, stream_name):
         # Submit retrieved value to stream.
         stream = getattr(self, stream_name)
         print(f"value= {value}")
-        stream.submit_data(np.array([value]).astype(stream.dtype))
+        try:
+            stream.submit_data(np.array([value]).astype(stream.dtype))
+        except ValueError:
+            raise ValueError('Error likely due to incorrect COM/VCP port after a reboot')
 
         return value
 
@@ -131,12 +134,15 @@ class ThorlabsMcls1(Service):
             # Last time this happened we identified the COM port in the device manager by unplugging / replugging
             # and then figuring the corresponding VCP port from the above debugging message.
 
-            if 'VCP0' in thing:
+            # Another way to figure out the COM port is to go to the MCLS1 Application and dicsonnect the source.
+            # When you reconnect the source, COM port it is connected to will be displayed.
+
+            if 'VCP3' in thing:
                 self.port = split[i - 1]
                 print(f'port number from thing ={self.port}')
                 break
         else:
-            raise Exception('Device VCP0 not found - The MCLS1 probably switched port after a reboot')
+            raise Exception('Device VCP3 not found - The MCLS1 probably switched COM port after a reboot')
 
         self.instrument_handle = self.UART_lib.fnUART_LIBRARY_open(self.port.encode(), MCLS1_COM.BAUD_RATE.value, 3)
 


### PR DESCRIPTION
As discussed in #304  and associated PR #326 the MCLS1 can change port (COM and VCP) after a computer reboot. 
This is hicat-specific and will need to be fixed so we don't have to do those PRs anymore. 

This PR updates the current VCP port on HICAT and also adds another test to provide more robustness to catch this issue. 

In the past we were "lucky" that the port had moved to an unused one, so the test in place was able to catch the missing port and raise the error.   This time around the port switched to a port in used by another device, and this resulted in a ValueError when submitting to the data stream (the data was presented as empty string). 

The PR adds a test for a ValueError at the data stream submission to be able to catch the issue and make it immediately clear that this is the port jumping issue. 