### PR TITLE
Remove hardcoded vcp_port names and instead pull values from the config

### DIFF
--- a/catkit2/services/thorlabs_mcls1/thorlabs_mcls1.py
+++ b/catkit2/services/thorlabs_mcls1/thorlabs_mcls1.py
@@ -105,6 +105,7 @@ class ThorlabsMcls1(Service):
 
         self.threads = {}
 
+        self.vcp_port = self.config.get('vcp_port', 'VCP0')
         # Use a reentrant lock to avoid deadlock when setting the channel.
         self.lock = threading.RLock()
 
@@ -137,12 +138,12 @@ class ThorlabsMcls1(Service):
             # Another way to figure out the COM port is to go to the MCLS1 Application and dicsonnect the source.
             # When you reconnect the source, COM port it is connected to will be displayed.
 
-            if 'VCP3' in thing:
+            if self.vcp_port in thing:
                 self.port = split[i - 1]
                 print(f'port number from thing ={self.port}')
                 break
         else:
-            raise Exception('Device VCP3 not found - The MCLS1 probably switched COM port after a reboot')
+            raise Exception(f'Device {self.vcp_port} not found - The MCLS1 probably switched port after a reboot')
 
         self.instrument_handle = self.UART_lib.fnUART_LIBRARY_open(self.port.encode(), MCLS1_COM.BAUD_RATE.value, 3)
 

--- a/catkit2/services/thorlabs_mcls1/thorlabs_mcls1.py
+++ b/catkit2/services/thorlabs_mcls1/thorlabs_mcls1.py
@@ -143,7 +143,7 @@ class ThorlabsMcls1(Service):
                 print(f'port number from thing ={self.port}')
                 break
         else:
-            raise Exception(f'Device {self.vcp_port} not found - The MCLS1 probably switched port after a reboot')
+            raise Exception(f'Device {self.vcp_port} not found - The MCLS1 probably switched COM port after a reboot')
 
         self.instrument_handle = self.UART_lib.fnUART_LIBRARY_open(self.port.encode(), MCLS1_COM.BAUD_RATE.value, 3)
 


### PR DESCRIPTION
Gets a VCP port value from the config instead of assuming a given hardcoded value. Requires users not using the default of 'VCP0' to include a `vcp_port` in the config if using the MCLS1. Future port changes will then not require additional catkit2 PRs. 

Closes #304. 

For additional discussion see #303, #326 and #397  