### PR TITLE
Bugfix/service run cleanup

### DIFF
--- a/catkit2/bindings.cpp
+++ b/catkit2/bindings.cpp
@@ -562,8 +562,15 @@ PYBIND11_MODULE(catkit_bindings, m)
 		.def_property_readonly("config", &Service::GetConfig)
 		.def("run", [](Service &service)
 		{
-			service.Run(error_check_python);
-		}, py::call_guard<py::gil_scoped_release>())
+			{
+				py::gil_scoped_release release;
+				service.Run(error_check_python);
+			}
+			// CleanupAttributes must be called with GIL held because
+			// m_Properties and m_Commands contain Python callbacks wrapped
+			// in std::function. Destroying them without the GIL causes crashes.
+			service.CleanupAttributes();
+		})
 		.def("open", &Service::Open)
 		.def("main", &Service::Main)
 		.def("close", &Service::Close)

--- a/catkit_core/Service.cpp
+++ b/catkit_core/Service.cpp
@@ -243,9 +243,6 @@ void Service::Run(void (*error_check)())
 
 	ArrayInfo info{'u', '=', 8, 1, {1, 1, 1, 1}, {8, 1, 1, 1}};
 	m_Testbed->GetMessageBroker()->PublishArray(m_ServiceId + "/heartbeat/get", {info, &timestamp});
-
-
-	CleanupAttributes();
 }
 
 void Service::CleanupAttributes()


### PR DESCRIPTION
Ensures the GIL is held when CleanupAttributes() destroys Python callbacks.

Previously, the GIL was released for the entire run() call, but CleanupAttributes() should execute with the GIL held
```
.def("run", [](Service &service)
{                                      // GIL: RELEASED (by call_guard)
    service.Run(error_check_python);   // GIL: RELEASED
                                       //   ↳ internally calls CleanupAttributes()
                                       //   ↳ Py_DECREF() 💥 NO GIL!
}
, py::call_guard<py::gil_scoped_release>())
                                       // GIL: RE-ACQUIRED (too late)
```

Now we use explicit scoped release ensuring the GIL is re-acquired before cleanup.

``` C++
.def("run", [](Service &service)
{                                          // GIL: HELD
    {                                      // GIL: HELD
        py::gil_scoped_release release;    // GIL: RELEASED ←──┐
        service.Run(error_check_python);   // GIL: RELEASED    │ scope of
    }                                      // GIL: HELD ←──────┘ 'release'
    
    service.CleanupAttributes();           // GIL: HELD ✓ Safe!
})
```

This fixes issue #359 