### PR TITLE
Fixes Issue: #405

### DIFF
--- a/docs/testbed_implementation.rst
+++ b/docs/testbed_implementation.rst
@@ -8,6 +8,7 @@ pyproject.toml, template docs, and a sample simulated service to be able to star
 To generate the testbed repository, from the command line run:
 
 .. code-block:: shell
+
    cookiecutter catkit2/cookiecutter-testbed
 
 You will then be prompted with a series of questions answered by typing directly in the console. One of these will specify the testbed name (e.g. ``my_testbed``).
@@ -15,6 +16,7 @@ You will then be prompted with a series of questions answered by typing directly
 You can then start the server for ``my_testbed`` by running:
 
 .. code-block:: shell
+   
    cd my_testbed
    pip install -e .
    my_testbed start server --simulated


### PR DESCRIPTION
Issue: The code blocks for the page https://spacetelescope.github.io/catkit2/testbed_implementation.html are visible through the [View page source], but invisible in the rendered HTML page.

Cause:  A syntax issue. Missing newline between ".. code-block:: shell" and the code blocks defined below each.

Verification: Built it locally with "make html" and confirmed adding newlines fixed the issue.

Currently: 
<img width="1912" height="968" alt="current" src="https://github.com/user-attachments/assets/f04927fd-bb4c-4bd5-9416-e6480f34bb6b" />

Fixed:
<img width="1892" height="967" alt="after" src="https://github.com/user-attachments/assets/c8484b0e-555b-424e-9c72-d23df9ea4838" />

