### PR TITLE
Update ZWO exposure time default parameters and make properties 

### DIFF
--- a/catkit2/services/zwo_camera/zwo_camera.py
+++ b/catkit2/services/zwo_camera/zwo_camera.py
@@ -138,7 +138,7 @@ class ZwoCamera(Service):
         self.gain = self.config.get('gain', 0)
         self.exposure_time_step_size = self.config.get('exposure_time_step_size', 1)
         self.exposure_time_offset_correction = self.config.get('exposure_time_offset_correction', 0)
-        self.exposure_time_base_step = self.config.get('exposure_time_base_step', 1)
+        self.exposure_time_base_step = self.config.get('exposure_time_base_step', 0)
         self.exposure_time = self.config.get('exposure_time', 1000)
 
         # Create datastreams


### PR DESCRIPTION
The default values to bypass any correction to the exposure time in the setter or getter when interacting with the ZWO API should be:

```
exposure_time_step_size: 1
 exposure_time_offset_correction: 0 
exposure_time_base_step: 0

```
To Do:

- [ ] make these values properties of the service so that they can be more easily set to the defaults for calibration experiments. 

fixes https://github.com/spacetelescope/catkit2/issues/434