### PR TITLE
Doc clarifications

### DIFF
--- a/catkit2/services/simple_simulator/simple_simulator.py
+++ b/catkit2/services/simple_simulator/simple_simulator.py
@@ -58,7 +58,6 @@ class SimpleSimulator(Simulator):
 
             camera.images.submit_data(image)
         except Exception as e:
-        except Exception as e:
             self.log.error(str(e))
 
 if __name__ == '__main__':

--- a/catkit2/services/simple_simulator/simple_simulator.py
+++ b/catkit2/services/simple_simulator/simple_simulator.py
@@ -1,5 +1,6 @@
 from catkit2.simulator import SimpleOpticalModel, Simulator
 import hcipy
+import numpy as np
 
 
 class SimpleSimulator(Simulator):
@@ -17,8 +18,6 @@ class SimpleSimulator(Simulator):
         self.model = SimpleOpticalModel()
         wavefronts = [hcipy.Wavefront(self.model.pupil_grid.ones() * 1e6)]
         self.model.set_wavefronts('pre_pupil', wavefronts)
-
-        self.images = self.make_data_stream('images', 'float64', self.model.focal_grid.shape, 20)
 
         self.update_atmosphere()
 
@@ -41,13 +40,24 @@ class SimpleSimulator(Simulator):
 
     def camera_readout(self, camera_name, power):
         image = power.shaped
+
+        # Add semi-realistic noise for this camera.
         image = hcipy.large_poisson(image)
         image[image > 2**16] = 2**16
         image = image.astype('float32')
 
+        # Put the image on the images datastream for this camera.
         try:
-            self.testbed.science_camera.images.update_parameters('float32', image.shape, 20)
-            self.testbed.science_camera.images.submit_data(image)
+            camera = self.testbed.get_service(camera_name)
+
+            if not camera.is_running:
+                return
+
+            if not np.allclose(camera.images.shape, image.shape):
+                camera.images.update_parameters('float32', image.shape, 20)
+
+            camera.images.submit_data(image)
+        except Exception as e:
         except Exception as e:
             self.log.error(str(e))
 

--- a/cookiecutter-testbed/{{cookiecutter.pypi_package_name}}/src/{{cookiecutter.project_slug}}/services/{{cookiecutter.project_slug}}_simulator/{{cookiecutter.project_slug}}_simulator.py
+++ b/cookiecutter-testbed/{{cookiecutter.pypi_package_name}}/src/{{cookiecutter.project_slug}}/services/{{cookiecutter.project_slug}}_simulator/{{cookiecutter.project_slug}}_simulator.py
@@ -13,7 +13,8 @@ class {{cookiecutter.project_slug.capitalize()}}Simulator(Simulator):
 
     def open(self):
         self.model = {{cookiecutter.project_slug.capitalize()}}OpticalModel(self.testbed.config['simulator'])
-        wavefronts = [hcipy.Wavefront(self.model.pupil_grid.ones() * 1e5)]
+        wvln = 1
+        wavefronts = [hcipy.Wavefront(self.model.pupil_grid.ones() * 1e5, wvln)]
         self.model.set_wavefronts('light_source', wavefronts)
         self.images = self.make_data_stream('images', 'float64', self.model.sample_camera_grid.shape, 20)
 

--- a/cookiecutter-testbed/{{cookiecutter.pypi_package_name}}/src/{{cookiecutter.project_slug}}/services/{{cookiecutter.project_slug}}_simulator/{{cookiecutter.project_slug}}_simulator.py
+++ b/cookiecutter-testbed/{{cookiecutter.pypi_package_name}}/src/{{cookiecutter.project_slug}}/services/{{cookiecutter.project_slug}}_simulator/{{cookiecutter.project_slug}}_simulator.py
@@ -1,6 +1,7 @@
 from catkit2.simulator import Simulator
 from {{cookiecutter.project_slug}}.{{cookiecutter.project_slug}}_optical_model import {{cookiecutter.project_slug.capitalize()}}OpticalModel
 import hcipy
+import numpy as np
 
 
 class {{cookiecutter.project_slug.capitalize()}}Simulator(Simulator):
@@ -16,17 +17,26 @@ class {{cookiecutter.project_slug.capitalize()}}Simulator(Simulator):
         wvln = 1
         wavefronts = [hcipy.Wavefront(self.model.pupil_grid.ones() * 1e5, wvln)]
         self.model.set_wavefronts('light_source', wavefronts)
-        self.images = self.make_data_stream('images', 'float64', self.model.sample_camera_grid.shape, 20)
 
     def camera_readout(self, camera_name, power):
         image = power.shaped
+
+        # Add semi-realistic noise for this camera.
         image = hcipy.large_poisson(image)
         image[image > 2**16] = 2**16
         image = image.astype('float32')
 
+        # Put the image on the images datastream for this camera.
         try:
-            self.testbed.sample_camera.images.update_parameters('float32', image.shape, 20)
-            self.testbed.sample_camera.images.submit_data(image)
+            camera = self.testbed.get_service(camera_name)
+
+            if not camera.is_running:
+                return
+
+            if not np.allclose(camera.images.shape, image.shape):
+                camera.images.update_parameters('float32', image.shape, 20)
+
+            camera.images.submit_data(image)
         except Exception as e:
             self.log.error(str(e))
 

--- a/docs/services/newport_xps_q8.rst
+++ b/docs/services/newport_xps_q8.rst
@@ -7,6 +7,9 @@ names are defined in the configuration file and have to follow the naming given 
 Each motor can define an arbitrary number of named positions. These named positions can can also call each other in a chain. This
 is useful for being able to save motor positions associated with different experiment modes.
 
+This service requires the setup of the environment variable ``CATKIT_NEWPORT_LIB_PATH`` to point to the directory containing
+the python drivers for the Newport XPS controller.
+
 Configuration
 -------------
 

--- a/docs/services/zwo_camera.rst
+++ b/docs/services/zwo_camera.rst
@@ -9,7 +9,11 @@ This service operates a ZWO camera. The following are the different types of ZWO
 - `ZWO ASI1600MM <https://agenaastro.com/zwo-asi1600mm-p-cmos-monochrome-astronomy-imaging-camera-pro.html>`_
 
 For camera specs, see the website links above.
-Note that using ZWO cameras requires a manual installation of drivers from `zwoastro.com <https://astronomy-imaging-camera.com/software-drivers>`_ 
+
+Note that using ZWO cameras requires a manual installation of the ZWO SDK from `zwoastro.com <https://www.zwoastro.com/layouts/download-others/>`_
+It also requires the setup of the environment variable ``ZWO_ASI_LIB`` to point to the right file from the SDK depending
+on your operating system. For example, on Windows, you would set ``ZWO_ASI_LIB`` to the path of the ``ASICamera2.dll``
+file from the SDK; for Linux, you would set it to the path of the ``libASICamera2.so`` file from the SDK.
 
 Configuration
 -------------

--- a/docs/testbed_implementation.rst
+++ b/docs/testbed_implementation.rst
@@ -12,7 +12,7 @@ Generating a Testbed Repository
 
 You can generate a testbed either directly from GitHub or from a local clone of the ``catkit2`` repository.
 
-Run Cookiecutter from the directory containing the repository:
+Run Cookiecutter from the directory containing the `catkit2` repository:
 
 .. code-block:: shell
 
@@ -73,7 +73,8 @@ Key fields:
    ``pypi_package_name`` (and typically ``project_slug``), not on
    ``project_name``.
 
-When the prompts are complete, Cookiecutter creates a new project directory using the selected package name.
+When the prompts are complete, Cookiecutter creates a new project directory using the selected package name and places
+it in the current working directory. You can easily move it to a different location, e.g. into your preferred repository.
 
 Starting the Testbed Server
 ---------------------------

--- a/docs/testbed_implementation.rst
+++ b/docs/testbed_implementation.rst
@@ -141,6 +141,7 @@ To access camera image through the camera service proxy, you can run the followi
 .. code-block:: python
 
    from catkit2 import TestbedProxy
+   import numpy as np
 
    testbed = TestbedProxy('127.0.0.1', 1234)
    cam = testbed.sample_camera


### PR DESCRIPTION
This PR contains a couple of doc updates and simulator example updates I found worthy changing while I was working on capsule setup over the first couple of days.

- Updates the Getting started instructions to be more explicit about how to handle the cookiecutter results
- Adds info to the ZWO camera documentation about the required environment variable that points to the vendor SDK
- Inserts an explicitly stated unit wavelength with its own variable in the template simulator provided by cookiecutter, as it is otherwise just silently assumed and hard to identify for necessary changes.
- Both for cookiecutter template simulator, as well as simple simulator: changes the `camera_readout()` function to actually use the passed in camera_name variable and not the hard-coded `science_camera`. Also removes the `images` data stream from the simulator as image data streams are standardly associated with a (simulated or hardware) camera.