### PR TITLE
Clean up error handling in Newport XPS service

### DIFF
--- a/catkit2/services/newport_xps_q8/newport_xps_q8.py
+++ b/catkit2/services/newport_xps_q8/newport_xps_q8.py
@@ -14,7 +14,7 @@ sys.path.append(library_path)
 try:
     import XPS_Q8_drivers
 except ModuleNotFoundError:
-    raise ModuleNotFoundError("To use the Newport XPS-Q8, you need to set the CATKIT_NEWPORT_LIB_PATH environment variable.")
+    raise ModuleNotFoundError(f"Could not import XPS_Q8_drivers from CATKIT_NEWPORT_LIB_PATH={library_path!r}.")
 
 
 class NewportXpsQ8(Service):

--- a/catkit2/services/newport_xps_q8/newport_xps_q8.py
+++ b/catkit2/services/newport_xps_q8/newport_xps_q8.py
@@ -6,14 +6,15 @@ import threading
 import numpy as np
 import traceback
 
+library_path = os.environ.get('CATKIT_NEWPORT_LIB_PATH')
+if not library_path:
+    raise RuntimeError("To use the Newport XPS-Q8, you need to set the CATKIT_NEWPORT_LIB_PATH environment variable.")
+sys.path.append(library_path)
+
 try:
-    library_path = os.environ.get('CATKIT_NEWPORT_LIB_PATH')
-    if library_path:
-        sys.path.append(library_path)
     import XPS_Q8_drivers
-except ImportError:
-    print("To use the Newport XPS-Q8, you need to set the CATKIT_NEWPORT_LIB_PATH environment variable.")
-    raise
+except ModuleNotFoundError:
+    raise ModuleNotFoundError("To use the Newport XPS-Q8, you need to set the CATKIT_NEWPORT_LIB_PATH environment variable.")
 
 
 class NewportXpsQ8(Service):


### PR DESCRIPTION
The error handling was a bit ambiguous so I separated out an error if there is no correct env variable set, or if it can simply not import the required module.

Tested on hardware and I was able to trigger both error messages independently.