### PR TITLE
Remove hard-coded sci cam flip in HiCAT ZWO camera (Revert #132)

### DIFF
--- a/catkit2/services/zwo_camera/zwo_camera.py
+++ b/catkit2/services/zwo_camera/zwo_camera.py
@@ -210,11 +210,7 @@ class ZwoCamera(Service):
                 img = self.camera.capture_video_frame(timeout=timeout)
 
                 with trace_interval('processing frame'):
-                    # 2023-10-26 Temporary fix for HiCAT
-                    if self.id == 'science_camera':
-                        self.images.submit_data(np.ascontiguousarray(np.flip(img.astype('float32'))))
-                    else:
-                        self.images.submit_data(img.astype('float32'))
+                    self.images.submit_data(img.astype('float32'))
         finally:
             # Stop acquisition.
             self.camera.stop_video_capture()


### PR DESCRIPTION
Reverting #132 after we switched HiCAT over to use the v2 service for the ZWO cameras, which inherit from the new camera base class (#131) that includes frame orientation handling.