### PR TITLE
Decouple ZWO exposure command from calibrated wall-clock reporting

### DIFF
--- a/catkit2/services/zwo_camera_v2/zwo_camera_v2.py
+++ b/catkit2/services/zwo_camera_v2/zwo_camera_v2.py
@@ -106,7 +106,7 @@ class ZwoCamera(CameraService):
         # Get exposure discretization parameters.
         self.exposure_time_step_size = self.config.get('exposure_time_step_size', 1)
         self.exposure_time_offset_correction = self.config.get('exposure_time_offset_correction', 0)
-        self.exposure_time_base_step = self.config.get('exposure_time_base_step', 1)
+        self.exposure_time_base_step = self.config.get('exposure_time_base_step', 0)
 
         def make_property_helper(name, read_only=False, requires_stopped_acquisition=False):
             if read_only:
@@ -208,18 +208,20 @@ class ZwoCamera(CameraService):
         # Report the calibrated wall-clock exposure time. The commanded (integer us) value
         # falls into one of the camera's hardware stairs, whose rising edges sit at
         # base_step + k * step_size. The representative wall-clock for that stair is its
-        # center (floor(...) + 0.5, since base_step is an edge, not a center), from which the
+        # center (stair_index + 0.5, since base_step is an edge, not a center), from which the
         # wall-clock offset is removed so that counts are proportional to the reported time
-        # through zero. With the default params (step_size=1) no staircase is known, so the
-        # commanded value is reported directly, leaving uncalibrated cameras unaffected.
+        # through zero.
+        #
+        # step_size <= 1 is the "uncalibrated" sentinel (the raw default 1/0/0): no staircase is
+        # known, so the commanded value is reported directly, leaving uncalibrated cameras
+        # unaffected. A real hardware step is many microseconds (~8.6 us for the ASI678MM).
         commanded, auto = self.camera.get_control_value(zwoasi.ASI_EXPOSURE)
 
         if self.exposure_time_step_size <= 1:
             return float(commanded - self.exposure_time_offset_correction)
 
-        stair_center = (self.exposure_time_step_size
-                        * (np.floor((commanded - self.exposure_time_base_step) / self.exposure_time_step_size) + 0.5)
-                        + self.exposure_time_base_step)
+        stair_index = np.floor((commanded - self.exposure_time_base_step) / self.exposure_time_step_size)
+        stair_center = self.exposure_time_base_step + self.exposure_time_step_size * (stair_index + 0.5)
 
         return float(stair_center - self.exposure_time_offset_correction)
 
@@ -229,6 +231,13 @@ class ZwoCamera(CameraService):
         # do NOT re-quantize onto the modeled staircase: the hardware applies its own native
         # discretization, and re-quantizing here would beat against the real stairs. With the
         # default offset_correction=0 this reduces to commanding the requested time.
+        #
+        # Notes on quantization/clamping:
+        #   * Exposure is quantized to integer microseconds here (int(round(...))); sub-microsecond
+        #     precision in the request is intentionally discarded (below our cameras' resolution).
+        #   * We clamp the command at 0, but the hardware additionally enforces its own minimum
+        #     exposure (~30 us on the ASI678MM), so any request below ~|offset_correction| collapses
+        #     to that minimum (the flat "clamped" floor seen in the staircase runs).
         exposure_time = max(int(round(exposure_time + self.exposure_time_offset_correction)), 0)
 
         self.camera.set_control_value(zwoasi.ASI_EXPOSURE, exposure_time)

--- a/catkit2/services/zwo_camera_v2/zwo_camera_v2.py
+++ b/catkit2/services/zwo_camera_v2/zwo_camera_v2.py
@@ -206,23 +206,30 @@ class ZwoCamera(CameraService):
 
     def get_exposure_time(self):
         # Report the calibrated wall-clock exposure time. The commanded (integer us) value
-        # is mapped onto the camera's true hardware staircase and the wall-clock offset is
-        # removed, so that counts are proportional to the reported time through zero. With
-        # the default params (step_size=1, base_step=1, offset_correction=0) this reduces to
-        # the identity, leaving uncalibrated cameras unaffected.
+        # falls into one of the camera's hardware stairs, whose rising edges sit at
+        # base_step + k * step_size. The representative wall-clock for that stair is its
+        # center (floor(...) + 0.5, since base_step is an edge, not a center), from which the
+        # wall-clock offset is removed so that counts are proportional to the reported time
+        # through zero. With the default params (step_size=1) no staircase is known, so the
+        # commanded value is reported directly, leaving uncalibrated cameras unaffected.
         commanded, auto = self.camera.get_control_value(zwoasi.ASI_EXPOSURE)
 
-        stair = (self.exposure_time_step_size
-                 * np.round((commanded - self.exposure_time_base_step) / self.exposure_time_step_size)
-                 + self.exposure_time_base_step)
+        if self.exposure_time_step_size <= 1:
+            return float(commanded - self.exposure_time_offset_correction)
 
-        return float(stair - self.exposure_time_offset_correction)
+        stair_center = (self.exposure_time_step_size
+                        * (np.floor((commanded - self.exposure_time_base_step) / self.exposure_time_step_size) + 0.5)
+                        + self.exposure_time_base_step)
+
+        return float(stair_center - self.exposure_time_offset_correction)
 
     def set_exposure_time(self, exposure_time):
-        # Command the raw requested exposure time without re-quantizing onto a modeled
-        # staircase; the hardware applies its own native discretization. Re-quantizing here
-        # would double-quantize against the camera's real stairs and cause beating artifacts.
-        exposure_time = max(int(round(exposure_time)), 0)
+        # Pre-compensate the calibrated wall-clock offset so the camera physically integrates
+        # (close to) the requested time, then command the raw integer-us value. We deliberately
+        # do NOT re-quantize onto the modeled staircase: the hardware applies its own native
+        # discretization, and re-quantizing here would beat against the real stairs. With the
+        # default offset_correction=0 this reduces to commanding the requested time.
+        exposure_time = max(int(round(exposure_time + self.exposure_time_offset_correction)), 0)
 
         self.camera.set_control_value(zwoasi.ASI_EXPOSURE, exposure_time)
 

--- a/catkit2/services/zwo_camera_v2/zwo_camera_v2.py
+++ b/catkit2/services/zwo_camera_v2/zwo_camera_v2.py
@@ -205,16 +205,26 @@ class ZwoCamera(CameraService):
         return cam_info['MaxHeight']
 
     def get_exposure_time(self):
-        exposure_time, auto = self.camera.get_control_value(zwoasi.ASI_EXPOSURE)
-        return exposure_time - self.exposure_time_offset_correction
+        # Report the calibrated wall-clock exposure time. The commanded (integer us) value
+        # is mapped onto the camera's true hardware staircase and the wall-clock offset is
+        # removed, so that counts are proportional to the reported time through zero. With
+        # the default params (step_size=1, base_step=1, offset_correction=0) this reduces to
+        # the identity, leaving uncalibrated cameras unaffected.
+        commanded, auto = self.camera.get_control_value(zwoasi.ASI_EXPOSURE)
+
+        stair = (self.exposure_time_step_size
+                 * np.round((commanded - self.exposure_time_base_step) / self.exposure_time_step_size)
+                 + self.exposure_time_base_step)
+
+        return float(stair - self.exposure_time_offset_correction)
 
     def set_exposure_time(self, exposure_time):
-        exposure_time += self.exposure_time_offset_correction
-        exposure_time = np.round((exposure_time - self.exposure_time_base_step) / self.exposure_time_step_size)
-        exposure_time = np.maximum(exposure_time, 0)
-        exposure_time = exposure_time * self.exposure_time_step_size + self.exposure_time_base_step
+        # Command the raw requested exposure time without re-quantizing onto a modeled
+        # staircase; the hardware applies its own native discretization. Re-quantizing here
+        # would double-quantize against the camera's real stairs and cause beating artifacts.
+        exposure_time = max(int(round(exposure_time)), 0)
 
-        self.camera.set_control_value(zwoasi.ASI_EXPOSURE, int(exposure_time))
+        self.camera.set_control_value(zwoasi.ASI_EXPOSURE, exposure_time)
 
     def get_gain(self):
         gain, _ = self.camera.get_control_value(zwoasi.ASI_GAIN)


### PR DESCRIPTION
## Summary

Rework how `zwo_camera_v2` handles the exposure-time staircase calibration so that:

1. **`get_exposure_time` reports the true wall-clock exposure time** (critical for experiments — counts are proportional to the reported time through the origin), and
2. **`set_exposure_time` pre-compensates the offset** so that asking for X µs makes the camera physically integrate ≈ X µs (instead of X + offset).

Both use the **same three** calibration parameters — no new parameter is introduced.

## Background: three exposure times

This reworks the exposure-time handling as part of a calibration effort for the exposure-time **staircase** of ZWO cameras. ZWO cameras quantize exposure onto a **native hardware staircase** and integrate for a fixed offset longer than the commanded value. We use the ASI678MM as the worked example throughout: it has a ~8.6 µs stair (appearing as an alternating 8/9 µs pattern because `ASI_EXPOSURE` is commanded in integer µs) and a fixed ~62 µs integration offset. The exact numbers are per-camera — notably the 8/9 µs alternation has **not** been observed on other ZWO cameras we have looked at — but the calibration approach is general.

| Quantity | Meaning |
|----------|---------|
| **requested** | what the user asks for (e.g. 100 µs) |
| **commanded** | the integer µs written to `ASI_EXPOSURE` |
| **wall-clock** | the *true physical* exposure the sensor uses (counts ∝ wall-clock through 0) |

Three parameters relate *commanded* → *wall-clock*:

- `exposure_time_step_size` — true hardware stair size (≈ 8.60 µs)
- `exposure_time_base_step` — location of the **first stair edge**
- `exposure_time_offset_correction` — commanded µs at which counts extrapolate to 0 (≈ −62 µs)

## The change

```python
def get_exposure_time(self):
    commanded, auto = self.camera.get_control_value(zwoasi.ASI_EXPOSURE)

    # step_size <= 1 is the "uncalibrated" sentinel (raw default 1/0/0): report the commanded value.
    if self.exposure_time_step_size <= 1:
        return float(commanded - self.exposure_time_offset_correction)

    stair_index = np.floor((commanded - self.exposure_time_base_step) / self.exposure_time_step_size)
    stair_center = self.exposure_time_base_step + self.exposure_time_step_size * (stair_index + 0.5)
    return float(stair_center - self.exposure_time_offset_correction)

def set_exposure_time(self, exposure_time):
    # Pre-compensate the offset, quantize to integer µs, and command the raw value (no re-quantize).
    exposure_time = max(int(round(exposure_time + self.exposure_time_offset_correction)), 0)
    self.camera.set_control_value(zwoasi.ASI_EXPOSURE, exposure_time)
```

- **`set_exposure_time`** applies the offset (`+ offset_correction`) and commands the raw integer µs. It deliberately does **not** re-quantize onto a modeled staircase — the hardware applies its own native discretization, and re-quantizing here would beat against the real stairs and produce irregular/merged steps. Net effect: request 100 µs → command 38 µs → the camera integrates ≈ 100 µs. Sub-µs precision in the request is intentionally discarded (below our cameras' resolution).
- **`get_exposure_time`** maps the commanded value to the **center** of the hardware stair it lands in and removes the offset, returning the true wall-clock time. Because `base_step` is a stair *edge*, the bin center is `stair_index + 0.5` (i.e. `floor(...) + 0.5`, not `round(...)`); using `round` misaligned the model by half a step and made the corrected staircase wobble around the y = a·x reference.

The calibration parameters become a **truth-telling** layer (reporting the real exposure) plus a **command pre-compensation**, rather than a command-shaping/re-quantizing one.

## Return type: float

`get_exposure_time` now returns a `float` (wall-clock times are generally non-integer). This is safe end-to-end: the wire `Value` type is a `std::variant<..., std::int64_t, double, ...>`, `ValueFromPython` maps Python `float` → `double`, and the `type`/`dtype` hints on `make_property` are not enforced.

## Backward compatibility

With the **default parameters** (`step_size = 1`, `base_step = 0`, `offset_correction = 0`) both methods reduce to the prior identity behaviour: the getter short-circuits to return the commanded value, and the setter commands `int(round(requested))`. No catkit2 config currently sets these parameters, so **all existing (uncalibrated) cameras are unaffected** until explicitly calibrated.

## ⚠️ Semantic change for calibrated cameras

The meaning of the three parameters has changed. Any deployment that set non-default values under the old command-shaping behaviour must **re-derive** them (from a `step_size = 1` calibration run with the correction disabled) for the new reporting + pre-compensation semantics.

## Known limitation: one-stair straddle at short exposures

On cameras that exhibit the alternating 8/9 µs behaviour (e.g. the ASI678MM), modeling that pattern with a single uniform `step_size` means the getter's bin boundaries can only sit within ±0.5 µs of the true hardware edges. At a few exposure times a commanded integer lands just across a boundary and the getter **misses a step**, reporting one stair (~8.6 µs) low. This is a **reporting-only** effect that occurs at isolated exposures (2 of 200 integer µs in our test run).

Its magnitude as a fraction of the exposure is `≈ step_size / T`, so it is worst at short exposures:

| exposure `T` | worst-case error at a straddle point |
|--------------|--------------------------------------|
| ~100 µs      | **≈ 8–9 %** (observed max 8.2 %)     |
| ~200 µs      | ≈ 4 %                                |
| ~500 µs      | ≈ 1.7 %                              |
| ≥ 1 ms       | < 1 %                                |

**Outside** these occasional straddle points the reported wall-clock time is accurate to an RMS of **0.3–0.5 %** across the range (dominated by photon noise at the shortest exposures). Also note the camera enforces a hardware minimum exposure (~30 µs commanded), so any request below ~|offset| collapses to that minimum (a flat reported floor around ~92 µs).

The straddles could be eliminated with a per-camera **lookup table of the measured stair edges** (instead of the uniform-step model) for short exposures — this removes them entirely in simulation. **We are not implementing the LUT for now**: the effect is reporting-only, confined to a handful of short exposures, and a uniform-step model keeps the service simple and camera-agnostic. Both effects are analysed in the companion `get_detector_staircase_analysis.ipynb` notebook.

## Testing

- ✅ Compiles (`py_compile`) and passes `flake8`.
- ✅ Verified numerically: default params reproduce the prior identity behaviour; reported wall-clock values land exactly on the stair-center grid, and counts are proportional to reported through the origin.
- ✅ **Hardware validated on the ASI678MM:** calibration run derives the three parameters; check runs (to 200 µs and 1000 µs) confirm reported wall-clock is proportional to counts through the origin with RMS deviation 0.3–0.5 %, apart from the documented one-stair straddle points.

